### PR TITLE
ENH: Add a structure for copying only the data from a Document

### DIFF
--- a/databroker/broker/struct.py
+++ b/databroker/broker/struct.py
@@ -1,0 +1,20 @@
+import mongoengine
+
+
+class BrokerStruct(object):
+    """
+    Copy the data out of a mongoengine.Document, including nested Documents,
+    but do not copy any of the mongo-specific methods or attributes.
+    """
+    def __init__(self, mongo_document):
+        """
+        Parameters
+        ----------
+        mongo_document : mongoengine.Document
+        """
+        fields = mongo_document._fields
+        for field in fields:
+            attr = getattr(mongo_document, field)
+            if isinstance(attr, mongoengine.Document):
+                attr = BrokerStruct(attr)
+            setattr(self, field, attr)


### PR DESCRIPTION
Here is good snippet of code for taking any `mongoengine.Document` and copying its data into a safer, simpler object to pass outside of DataBroker.

What do you think? And what do you think of the name?

```
In [3]: events = metadataStore.api.analysis.find_event(run)

In [4]: event = events[0]

In [5]: len(dir(event))  # including dangerous methods like `drop_collection()`
Out[5]: 100

In [6]: from databroker.broker.struct import BrokerStruct

In [7]: safe_event = BrokerStruct(event)  # copies the data from this Document and nested Documents

# tab completion shows only the field attributes remain
In [9]: safe_event.
safe_event.data              safe_event.seq_no
safe_event.descriptor        safe_event.time
safe_event.id                safe_event.time_as_datetime

# the attributes of the nested documents are here too, and they still tab-complete
In [9]: safe_event.descriptor.
safe_event.descriptor.begin_run_event  safe_event.descriptor.id
safe_event.descriptor.data_keys        

In [9]: safe_event.descriptor.data_keys
Out[9]: 
{u'Tsam': {u'source': u'PV3'},
 u'linear_motor': {u'source': u'PV1'},
 u'scalar_detector': {u'source': u'PV2'}}
```
