### PR TITLE
New broker api

### DIFF
--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,1 +1,3 @@
-from .simple_broker import get_last
+from .simple_broker import DataBroker
+
+DataBroker = DataBroker()  # singleton

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import six  # noqa
 from collections import defaultdict, Iterable, deque
 from .. import sources
+from metadataStore.api import Document
 import os
 # Note: Invoke contents of sources at the func/method level so that it
 # respects runtime switching between real and dummy sources.
@@ -10,126 +11,134 @@ import os
 # These should be specified elsewhere in a way that can be easily updated.
 # This is merely a placeholder, but it can be used with the real
 # channelarchiver as well as the dummy one.
-POPULAR_CHANNELS = ['SR11BCM01:LIFETIME_MONITOR', 'SR11BCM01:CURRENT_MONITOR']
-_SCARY_MONGOENGINE_METHODS = ['drop_collection', 'delete']
 
 
-def get_events_by_run(runs, ca_host, channels=None):
-    """
-    Get Events from given run(s).
+class DataBroker(object):
 
-    Parameters
-    ----------
-    args : one or a list of BeginRun or EndRun objects
-    ca_host : URL string
-        the URL of your archiver's ArchiveDataServer.cgi. For example,
-        'http://cr01arc01/cgi-bin/ArchiveDataServer.cgi'
-    channels : list, optional
-        All queries will return applicable data from the N most popular
-        channels. If data from additional channels is needed, their full
-        identifiers (not human-readable names) must be given here as a list
-        of strings.
+    @classmethod
+    def __getitem__(cls, key):
+        # Define imports here so that sources can be switched
+        # at run time.
+        find_last = sources.metadataStore.api.find_last
+        find_run_start = sources.metadataStore.api.find_run_start
+        return_list = True
+        if isinstance(key, slice):
+            # Slice on recent runs.
+            if key.start is not None and key.start > -1:
+                raise ValueError("Slices must be negative. The most recent "
+                    "run is referred to as -1.")
+            if key.stop is not None and key.stop > -1:
+                raise ValueError("Slices must be negative. The most recent "
+                    "run is referred to as -1.")
+            if key.stop is not None:
+                num = key.stop - key.start
+            else:
+                num = 1
+            headers = find_last(-key.start)[:num:key.step]
+        elif isinstance(key, int):
+            return_list = False
+            if key > -1:
+                headers = find_run_start(scan_id=key)
+                if len(headers) == 0:
+                    raise ValueError("No such run found.")
+            else:
+                headers = find_last(-key)
+        else:
+            ValueError("Must give an integer scan ID like [6] or a slice "
+                       "into past scans like [-5], [-5:], or [-5:-9:2].")
+        [_build_header(h) for h in headers]
+        if not return_list:
+            headers = headers[0]
+        return headers
 
-    Returns
-    -------
-    data : list of Event objects
-    """
-    find_event = sources.metadataStore.api.find_event
+    @classmethod
+    def fetch_events(cls, runs, ca_host=None, channels=None):
+        """
+        Get Events from given run(s).
 
-    # Normalize input: runs is a list of BeginRun and/or EndRun objects.
-    if not isinstance(runs, Iterable):
-        runs = [runs]
+        Parameters
+        ----------
+        runs : one RunHeader or a list of them
+        ca_host : URL string
+            the URL of your archiver's ArchiveDataServer.cgi. For example,
+            'http://cr01arc01/cgi-bin/ArchiveDataServer.cgi'
+        channels : list, optional
+            All queries will return applicable data from the N most popular
+            channels. If data from additional channels is needed, their full
+            identifiers (not human-readable names) must be given here as a list
+            of strings.
 
-    runs = [find_event(run) for run in runs]
-    descriptors = [descriptor for run in runs for descriptor in run]
-    events = [event for descriptor in descriptors for event in descriptor]
-    [fill_event(event) for event in events]
-    return events
+        Returns
+        -------
+        data : a flat list of Event objects
+        """
+        find_event = sources.metadataStore.api.find_event
 
+        if not isinstance(runs, Iterable):
+            runs = [runs]
 
-def get_events_in_time_range(start_time, end_time, ca_host, channels=None):
-    """
-    Get Events that occurred between two times.
+        runs = [find_event(run) for run in runs]
+        descriptors = [descriptor for run in runs for descriptor in run]
+        events = [event for descriptor in descriptors for event in descriptor]
+        [fill_event(event) for event in events]
 
-    Parameters
-    ----------
-    start_time : string or datetime object, optional
-        e.g., datetime.datetime(2015, 1, 1) or '2015-01-01' (ISO format)
-    end_time : string or datetime object, optional
-        e.g., datetime.datetime(2015, 1, 1) or '2015-01-01' (ISO format)
-    ca_host : URL string
-        the URL of your archiver's ArchiveDataServer.cgi. For example,
-        'http://cr01arc01/cgi-bin/ArchiveDataServer.cgi'
-    channels : list, optional
-        All queries will return applicable data from the N most popular
-        channels. If data from additional channels is needed, their full
-        identifiers (not human-readable names) must be given here as a list
-        of strings.
+        if channels is not None:
+            if ca_host is None:
+                ca_host = _get_local_ca_host()
+            all_times = [event.time for event in events]
+            archiver_data = _get_archiver_data(ca_host, channels,
+                                               min(all_times), max(all_times))
+        return events
 
-    Returns
-    -------
-    data : list of Event objects
-    """
-    raise NotImplementedError()
+    @classmethod
+    def find_headers(cls, **kwargs):
+        """
+        For now, pass through to metadataStore.api.analysis.find_header
 
+        Parameters
+        ----------
+        **kwargs
 
-def explore(**kwargs):
-    """
-    For now, pass through to metadataStore.api.analysis.find_header
-
-    Parameters
-    ----------
-    **kwargs
-
-    Returns
-    -------
-    data : list
-        Header objects
-    """
-    find_header = sources.metadataStore.api.find_header
-    return find_header(**kwargs)
-
-
-def _assmeble_output(events):
-    """Get data from external sources and channel archiver from mds events
-
-    Convert event objects into list
-
-    Parameters
-    ----------
-    events : list
-        List of metadataStore.odm_templates.Event objects
-
-    Returns
-    -------
-
-    """
-    "Used by get_event_* functions"
-    data = [_scrape_event(event) for event in events]
-
-    archiver_data = get_archiver_data(ca_host, start_time, end_time)
-    # Format data from the Archiver like data from the events, and combine.
-    for ch_name, ch_data in zip(channels, archiver_result):
-        data += [(time, {ch_name: value}) for time, value in
-                 zip(ch_data.times, ch_data.values)]
-    return data
+        Returns
+        -------
+        data : list
+            Header objects
+        """
+        find_header = sources.metadataStore.api.find_header
+        run_start = find_header(**kwargs)
+        headers = [_build_header(rs) for rs in run_start]
+        return headers
 
 
-def _get_archiver_data(ca_host, start_time, end_time, channels=None):
-    # Get data from commonly-used Channel Archiver channels plus any
-    # specified in the call.
-    if channels is None:
-        channels = []
-    channels = list(set(channels) | set(POPULAR_CHANNELS))
+def _get_archiver_data(ca_host, channels, start_time, end_time):
     archiver = sources.channelarchiver.Archiver(ca_host)
     archiver_result = archiver.get(channels, start_time, end_time,
                                    interpolation='raw')  # never interpolate
-    return archiver_result
+    # Put archiver data into Documents, minimicking a MDS event stream.
+    events = list()
+    for ch_name, ch_data in zip(channels, archiver_result):
+        # Build a Event Descriptor.
+        descriptor = dict()
+        descriptor.time = start_time
+        descriptor['data_keys'] = {ch_name: dict(source=ch_name,
+                                   shape=[], dtype='number')}
+        descriptor = Document(descriptor)
+        for time, value in zip(ch_data.times, ch_data, values):
+            # Build an Event.
+            event = dict()
+            event['descriptor'] = descriptor
+            event['time'] = time
+            event['data'] = {ch_name: (value, time)}
+            event = Document(event)
+            events.append(event)
+    return events
+
 
 class LocationError(ValueError):
     pass
 
-def _get_local_cahost():
+
+def _get_local_ca_host():
     """Obtain the url for the cahost by using the uname() function to
     grab the local beamline id
 
@@ -145,56 +154,6 @@ def _get_local_cahost():
                             'obtain data from.')
     return 'http://' + beamline_id + '-ca/cgi-bin/ArchiveDataServer.cgi'
 
-
-def get_last_headers(num_to_get=1):
-    """Helper function that grabs the last `num_to_get` headers from
-    metadataStore. Also adds an `event_descriptors` field to the
-    run starts. Because the run_start has a reference to
-    metadatastore `sample` `beamline_config` documents, they are dereferenced
-    by metadatastore and are thus part of the run_start already.  Once we
-    have a better grasp of `end_run_events` they will also be inserted into
-    the run_start document, thus turning it into the `run_header`
-
-    Note: Currently used by replay. Changing this API might break replay.
-
-    Parameters
-    ----------
-    num_to_get : int
-        The number of headers to construct and return
-
-    Returns
-    -------
-    run_headers : list
-        List of constructed run headers
-    """
-    mdsapi = sources.metadataStore.api
-    bre_list = mdsapi.find_last(num_to_get)
-    headers = deque()
-    for bre in bre_list:
-        bre.event_descriptors = [evd for evd
-                                 in mdsapi.find_event_descriptor(bre)]
-        headers.append(bre)
-    return list(headers)
-
-
-def get_last(channels=None, ca_host=None):
-    mdsapi = sources.metadataStore.api
-    bre, = mdsapi.find_last()
-    events = mdsapi.find_event(bre)
-    events = [ev for desc in events for ev in desc]
-    # fill in the events from any external data sources
-    [fill_event(event) for event in events]
-    tstart = bre.time
-    tfinish = events[0].time
-    if ca_host is None:
-        try:
-            ca_host = _get_local_cahost()
-        except LocationError:
-            sources.switch(channelarchiver=False)
-
-    # archiver_data = _get_archiver_data(ca_host, tstart, tfinish, channels)
-
-    return {'run_start': bre, 'events': events}
 
 def _inspect_descriptor(descriptor):
     """
@@ -222,25 +181,8 @@ def fill_event(event):
             event.data[data_key][0]= retrieve_data(value)
 
 
-def _scrape_event(event):
-    """
-    Return event.time, data where data is a dict of field names and values.
-
-    Example
-    -------
-    >>> _parse_event(event)
-    <UNIX EPOCH TIME>, {'chan1': <value>, 'chan2': <value>}
-    """
-    retrieve_data = sources.fileStore.commands.retrieve_data
-    is_external = _inspect_descriptor(event.ev_desc)
-    data = dict()
-    for data_key, (value, _) in event.data.items():
-        # Notice that the timestamp is not returned to the user, only the
-        # event time, below.
-        if is_external[data_key]:
-            # Retrieve a numpy array from filestore
-            data[data_key] = retrieve_data(value)
-        else:
-            # Store the scalar value, a Python primitive, directly.
-            data[data_key] = value
-    return event.time, data
+def _build_header(run_start):
+    fed = sources.metadataStore.api.find_event_descriptor
+    run_start.event_descriptors = fed(run_start)
+    # TODO merge contents of RunEnd
+    run_start._name = 'Header'

--- a/dataportal/muxer/__init__.py
+++ b/dataportal/muxer/__init__.py
@@ -1,0 +1,1 @@
+from .data_muxer import DataMuxer

--- a/dataportal/replay/muxer/model.py
+++ b/dataportal/replay/muxer/model.py
@@ -5,13 +5,13 @@ from collections import deque
 from atom.api import (Atom, Typed, List, Range, Dict, observe, Str, Enum, Int,
                       Bool, ReadOnly, Tuple, Float)
 from dataportal.muxer.api import DataMuxer
-from dataportal.broker import simple_broker
+from dataportal.broker import DataBroker
 from dataportal.muxer.data_muxer import ColSpec
 from metadataStore.api import Document
 
 
 def get_events(run_header):
-    return simple_broker.get_events_by_run(run_header)
+    return DataBroker.fetch_events(run_header)
 
 
 class ColumnModel(Atom):
@@ -153,7 +153,7 @@ class MuxerModel(Atom):
         grab it
         """
         print('getting new data from the data broker')
-        events = simple_broker.get_events_by_run(self.run_header, None)
+        events = get_events(self.run_header)
         if self.data_muxer is None:
             # this will automatically trigger the key updating
             self.data_muxer = DataMuxer.from_events(events)

--- a/dataportal/replay/search/model.py
+++ b/dataportal/replay/search/model.py
@@ -3,7 +3,7 @@
 import six
 from collections import deque
 from atom.api import Atom, Typed, List, Range, Dict, observe, Str, Bool
-from dataportal.broker import simple_broker
+from dataportal.broker import DataBroker
 from metadataStore.api import Document
 
 
@@ -42,7 +42,7 @@ class GetLastModel(Atom):
 
     @observe('num_to_retrieve')
     def num_changed(self, changed):
-        self.headers = simple_broker.get_last_headers(self.num_to_retrieve)
+        self.headers = DataBroker[-self.num_to_retrieve:]
         run_starts_as_dict = {}
         run_starts_keys = {}
         header = [['KEY NAME', 'DATA LOCATION', 'PV NAME']]


### PR DESCRIPTION
This implements Thursday's discussion. In brief, you can get headers like so:

```
from dataportal.broker import DataBroker as db

db[13]  # scan id 13
db[-1]  # last scan
db[-5:]  # last five scans
db[-100::10]  # every 10th of the last 100 scans
db.find_headers(owner='blah', ...)  # any kwargs known to MDS
```

All of these returns a Header or Headers. From these get the associated events:

```
events = db.fetch_events(headers)
```

Which, as before, you can pass to a Muxer (née Muggler)

```
from dataportal.muxer import DataMuxer
dm = DataMuxer(events)
```
