### PR TITLE
FIX: exit-report -> exit-reason

### DIFF
--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -203,7 +203,7 @@ def _build_header(run_start):
     if run_stop is not None:
         adds['stop_time'] = (run_stop, 'time')
         adds['stop_datetime'] = (run_stop, 'time_as_datetime')
-        adds['exit_report'] = (run_stop, 'reason')
+        adds['exit_reason'] = (run_stop, 'reason')
         deletes.append((run_stop, '_name'))
         deletes.append((run_stop, 'run_start'))
         add_to_id['run_stop_uid'] = (run_stop, 'uid')


### PR DESCRIPTION
Following up on conversation in #65, I fully agree with comments from @ericdill and relayed comments from Claudio.

I only quibble with introducing a new word -- report -- when we already have `reason` in the spec. I agree Header.reason is misleading, but Header.exit_reason seems OK.
