### PR TITLE
WIP: Updating a DataMuxer

### DIFF
--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -5,7 +5,7 @@ from collections import defaultdict, Iterable, deque
 from .. import sources
 from metadatastore.api import (Document, find_last, find_run_start,
                                find_event_descriptor, find_run_stop,
-                               fetch_events)
+                               fetch_events, find_event)
 from filestore.api import retrieve
 import os
 

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -112,6 +112,26 @@ class DataBroker(object):
             _build_header(rs)
         return run_start  # these have been built out into headers
 
+    @classmethod
+    def update(cls, dm):
+        """
+        Update the contents of a DataMuxer.
+
+        Inspect the Header(s) already represented in the DataMuxer
+        instance, and append all associated Events.
+
+        The DataMuxer is updated in place; nothing is returned.
+
+        Parameters
+        ----------
+        dm : DataMuxer
+        """
+        events = cls.fetch_events(dm.headers)
+        # Yes, this includes all the Events, including ones the DataMuxer
+        # may already have. The append operation below avoids keeping
+        # duplicates.
+        dm.append_events(events)
+
 
 def _get_archiver_data(ca_host, channels, start_time, end_time):
     archiver = sources.channelarchiver.Archiver(ca_host)

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -35,12 +35,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+import copy
 from collections import namedtuple, deque
 import logging
 import pandas as pd
 import numpy as np
 from scipy.interpolate import interp1d
 import pandas.core.groupby  # to get custom exception
+from ..broker.simple_broker import _build_header
 
 
 logger = logging.getLogger(__name__)
@@ -173,6 +175,7 @@ class DataMuxer(object):
         self._timestamps_as_data = set()
         self._known_events = set()
         self._known_descriptors = set()
+        self.headers = set()
         self._stale = True
 
     @classmethod
@@ -272,6 +275,10 @@ class DataMuxer(object):
                 # TODO Look up source-specific default in a config file
                 # or some other source of reference data.
                 self.col_info[name] = col_info
+        if hasattr(descriptor, 'run_start'):
+            header = copy.copy(descriptor.run_start)
+            _build_header(header)  # run_start -> header in place
+            self.headers.add(header)
         self._known_descriptors.add(descriptor.id)
 
     @property

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -14,6 +14,7 @@ from .. import sources
 from ..sources import channelarchiver as ca
 from ..sources import switch
 from ..broker import DataBroker as db
+from ..examples.sample_data import temperature_ramp
 
 from nose.tools import make_decorator
 from nose.tools import (assert_equal, assert_raises, assert_true,
@@ -47,9 +48,11 @@ def setup():
                          owner='docbrown', beamline_id='example',
                          beamline_config=insert_beamline_config({}, time=0.))
     for i in range(5):
-        insert_run_start(time=float(i), scan_id=i + 1,
-                         owner='nedbrainard', beamline_id='example',
-                         beamline_config=insert_beamline_config({}, time=0.))
+        rs = insert_run_start(time=float(i), scan_id=i + 1,
+                              owner='nedbrainard', beamline_id='example',
+                              beamline_config=insert_beamline_config(
+                                  {}, time=0.))
+        temperature_ramp.run(rs)
 
 
 def teardown():
@@ -64,7 +67,6 @@ def test_basic_usage():
     header = db.find_headers(owner='nedbrainard')
     header = db.find_headers(owner='this owner does not exist')
     events = db.fetch_events(header)
-
 
 def test_indexing():
     header = db[-1]


### PR DESCRIPTION
It works like this:

```
header = DataBroker[-1]  # for example
events = DataBroker.fetch_events(header)
dm = DataMuxer.from_events(events)

# more Events are added to MDS...

DataBroker.update(dm)
```

DataBroker is using only public attributes of `dm` to do its work. It's no problem if Events are added out of order. DataBroker dumps _all_ the Events it finds in the DataMuxer, and DataMuxer takes care of identifying duplicates.

I christened the method `DataBroker.update`. Or we could call it `DataBroker.refresh`. I like either one.
