### PR TITLE
ENH: 'watermark' util func gives versions of all deps

### DIFF
--- a/dataportal/tests/test_misc.py
+++ b/dataportal/tests/test_misc.py
@@ -1,0 +1,4 @@
+from ..utils.diagnostics import watermark
+
+def test_watermark():
+    watermark()

--- a/dataportal/utils/diagnostics.py
+++ b/dataportal/utils/diagnostics.py
@@ -1,0 +1,47 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from collections import OrderedDict
+import importlib
+import six
+
+
+def watermark():
+    """
+    Give the version of each of the dependencies -- useful for bug reports.
+
+    Returns
+    -------
+    result : dict
+        mapping the name of each package to its version string or, if an
+        optional dependency is not installed, None
+    """
+    packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas', 'pims',
+                'pyyaml', 'metadatastore', 'filestore',
+                'channelarchiver', 'bubblegum']
+    result = OrderedDict()
+    for package_name in packages:
+        try:
+            package = importlib.import_module(package_name)
+        except ImportError:
+            result[package_name] = None
+        else:
+            version = package.__version__
+
+    # enaml provides its version differently
+    try:
+        import enaml
+    except ImportError:
+        result['enaml'] = None
+    else:
+        from enaml.version import version_info
+        result['enaml'] = _make_version_string(version_info)
+
+    # ...as does Python
+    version_info = sys.version_info
+    result['python'] = _make_version_string(version_info)
+    return result
+
+def _make_version_string(version_info):
+    version_string = '.'.join(map(str, [version_info[0], version_info[1],
+                                  version_info[2]]))
+    return version_string

--- a/dataportal/utils/diagnostics.py
+++ b/dataportal/utils/diagnostics.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from collections import OrderedDict
 import importlib
+import sys
 import six
 
 
@@ -25,7 +26,11 @@ def watermark():
         except ImportError:
             result[package_name] = None
         else:
-            version = package.__version__
+            try:
+                version = package.__version__
+            except AttributeError as err:
+                version = "FAILED TO DETECT: {0}".format(err)
+        result[package_name] = version
 
     # enaml provides its version differently
     try:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
               'dataportal.examples.sample_data',
               'dataportal.broker', 'dataportal.muxer',
               'dataportal.sources', 'dataportal.sources.dummy_sources',
+              'dataportal.utils',
               'dataportal.replay', 'dataportal.replay.muxer',
               'dataportal.replay.scalar', 'dataportal.replay.search',
               ],


### PR DESCRIPTION
This will not work until our packages (MDS, FS, bubblegum) have a `__version__` attribute. The channelarchiver package fortunately already has one.
