### PR TITLE
ENH: Implemented --live command line flag

### DIFF
--- a/dataportal/replay/muxer/view.enaml
+++ b/dataportal/replay/muxer/view.enaml
@@ -46,6 +46,7 @@ enamldef MuxerController(Container):
         timeout ::
             muxer_model.get_new_data()
     TimerButton: refresh_button:
+        checked := muxer_model.auto_updating
         timer = the_timer
         text = "Automatically update data"
     Container: update_rate:
@@ -56,7 +57,7 @@ enamldef MuxerController(Container):
         SpinBox: update_input:
             minimum = 1000
             maximum = 3600000
-            special_value_text = 'Autotune'
+            #special_value_text = 'Autotune'
             value := muxer_model.update_rate
             suffix = ' ms'
             single_step << value / 100

--- a/dataportal/replay/replay.py
+++ b/dataportal/replay/replay.py
@@ -68,10 +68,10 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_args()
-    print('args: {}'.format(args))
-    params_dict = define_default_params()
     if args.live:
         params_dict = define_ophyd_params()
+    else:
+        params_dict = define_default_params()
     app = QtApplication()
     ui = create_default_ui(params_dict)
     ui.show()

--- a/dataportal/replay/replay.py
+++ b/dataportal/replay/replay.py
@@ -10,10 +10,7 @@ from dataportal.replay.muxer import MuxerModel
 from dataportal.replay.scalar import ScalarCollection
 import sys
 
-import metadatastore
-
-#metadatastore.conf.mds_config['host'] = 'localhost'
-#metadatastore.conf.mds_config['database'] = 'test'
+import argparse
 
 with enaml.imports():
     from dataportal.replay.replay_view import MainView
@@ -29,6 +26,7 @@ def define_ophyd_params():
     params_dict = {
         'search_tab_index': 1,
         'automatically_update_header': True,
+        'muxer_auto_update': True,
     }
     return params_dict
 
@@ -40,6 +38,8 @@ def create_default_ui(init_params_dict):
     watch_headers_model = WatchForHeadersModel()
     watch_headers_model.auto_update = init_params_dict['automatically_update_header']
 
+    if 'muxer_auto_update' in init_params_dict:
+        muxer_model.auto_updating = init_params_dict['muxer_auto_update']
 
     # set up observers
     muxer_model.observe('data_muxer', scalar_collection.new_data_muxer)
@@ -59,10 +59,18 @@ def create_default_ui(init_params_dict):
                          init_params=init_params_dict)
     return main_view
 
+def define_parser():
+    parser = argparse.ArgumentParser(description='Launch a data viewer')
+    parser.add_argument('--live', action="store_true",
+                        help="Launch Replay configured for viewing live data")
+    return parser
+
 def main():
-    args = sys.argv
+    parser = define_parser()
+    args = parser.parse_args()
+    print('args: {}'.format(args))
     params_dict = define_default_params()
-    if '--ophyd' in args:
+    if args.live:
         params_dict = define_ophyd_params()
     app = QtApplication()
     ui = create_default_ui(params_dict)

--- a/dataportal/replay/replay.py
+++ b/dataportal/replay/replay.py
@@ -22,7 +22,7 @@ def define_default_params():
     }
     return params_dict
 
-def define_ophyd_params():
+def define_live_params():
     params_dict = {
         'search_tab_index': 1,
         'automatically_update_header': True,
@@ -69,7 +69,7 @@ def main():
     parser = define_parser()
     args = parser.parse_args()
     if args.live:
-        params_dict = define_ophyd_params()
+        params_dict = define_live_params()
     else:
         params_dict = define_default_params()
     app = QtApplication()

--- a/dataportal/replay/replay.py
+++ b/dataportal/replay/replay.py
@@ -4,9 +4,11 @@ from enaml.qt.qt_application import QtApplication
 import numpy as np
 
 from dataportal.muxer.api import DataMuxer
-from dataportal.replay.search import GetLastModel
+from dataportal.replay.search import (GetLastModel, WatchForHeadersModel,
+                                      DisplayHeaderModel)
 from dataportal.replay.muxer import MuxerModel
 from dataportal.replay.scalar import ScalarCollection
+import sys
 
 import metadatastore
 
@@ -16,26 +18,54 @@ import metadatastore
 with enaml.imports():
     from dataportal.replay.replay_view import MainView
 
+def define_default_params():
+    params_dict = {
+        'search_tab_index': 0,
+        'automatically_update_header': False,
+    }
+    return params_dict
 
-def create_ui():
+def define_ophyd_params():
+    params_dict = {
+        'search_tab_index': 1,
+        'automatically_update_header': True,
+    }
+    return params_dict
+
+def create_default_ui(init_params_dict):
     get_last_model = GetLastModel()
-
     muxer_model = MuxerModel()
-
     scalar_collection = ScalarCollection()
+    display_header_model = DisplayHeaderModel()
+    watch_headers_model = WatchForHeadersModel()
+    watch_headers_model.auto_update = init_params_dict['automatically_update_header']
+
 
     # set up observers
     muxer_model.observe('data_muxer', scalar_collection.new_data_muxer)
     muxer_model.new_data_callbacks.append(scalar_collection.notify_new_data)
+
+    watch_headers_model.observe('header', display_header_model.new_run_header)
+    get_last_model.observe('header', display_header_model.new_run_header)
+    display_header_model.observe('header', muxer_model.new_run_header)
+
+
     get_last_model.observe('selected', scalar_collection.header_changed)
 
     main_view = MainView(get_last_model=get_last_model, muxer_model=muxer_model,
-                         scalar_collection=scalar_collection)
+                         scalar_collection=scalar_collection,
+                         watch_headers_model=watch_headers_model,
+                         display_header_model=display_header_model,
+                         init_params=init_params_dict)
     return main_view
 
 def main():
+    args = sys.argv
+    params_dict = define_default_params()
+    if '--ophyd' in args:
+        params_dict = define_ophyd_params()
     app = QtApplication()
-    ui = create_ui()
+    ui = create_default_ui(params_dict)
     ui.show()
     app.start()
 

--- a/dataportal/replay/replay_view.enaml
+++ b/dataportal/replay/replay_view.enaml
@@ -1,18 +1,27 @@
-from dataportal.replay.search import GetLastView
+from dataportal.replay.search import (GetLastView, WatchForHeadersView,
+                                      DisplayHeaderView)
 from dataportal.replay.muxer import MuxerController
 from dataportal.replay.scalar import PlotView, PlotControls
 
 from enaml.widgets.api import (MainWindow, Container, DockArea, DockItem)
-from enaml.layout.api import VSplitLayout, HSplitLayout
+from enaml.layout.api import VSplitLayout, HSplitLayout, TabLayout
 
 enamldef MainView(MainWindow): main_view:
     attr get_last_model
     attr muxer_model
     attr scalar_collection
+    attr watch_headers_model
+    attr display_header_model
+    attr init_params
     Container: container:
         DockArea: area:
             layout = HSplitLayout(
-                HSplitLayout('search', 'muxer', 'scalar plot controls'),
+                HSplitLayout(
+                    VSplitLayout(
+                        TabLayout('search', 'watch_header',
+                                  index=init_params['search_tab_index']),
+                        'header_view'),
+                    'muxer', 'scalar plot controls'),
                 'scalar plot'
             )
             DockItem:
@@ -21,6 +30,16 @@ enamldef MainView(MainWindow): main_view:
                 GetLastView:
                     get_last_model = main_view.get_last_model
                     muxer_model = main_view.muxer_model
+            DockItem:
+                name = 'watch_header'
+                title = "Most Recent Header"
+                WatchForHeadersView:
+                    watch_headers_model = main_view.watch_headers_model
+            DockItem:
+                name = 'header_view'
+                title = "Run Summary"
+                DisplayHeaderView:
+                    display_header_model = main_view.display_header_model
             DockItem:
                 name = 'muxer'
                 title = 'Muxer'

--- a/dataportal/replay/search/__init__.py
+++ b/dataportal/replay/search/__init__.py
@@ -6,10 +6,11 @@ logger = logging.getLogger(__name__)
 try:
     import enaml
 
-    from .model import GetLastModel
+    from .model import GetLastModel, DisplayHeaderModel, WatchForHeadersModel
 
     with enaml.imports():
-        from .view import GetLastView, GetLastWindow
+        from .view import (GetLastView, GetLastWindow, WatchForHeadersView,
+                           DisplayHeaderView)
 
 except ImportError:
     if six.PY3:

--- a/dataportal/replay/search/model.py
+++ b/dataportal/replay/search/model.py
@@ -2,12 +2,99 @@
 
 import six
 from collections import deque
-from atom.api import Atom, Typed, List, Range, Dict, observe, Str, Bool
+from atom.api import Atom, Typed, List, Range, Dict, observe, Str, Bool, Int
 from dataportal.broker import DataBroker
 from metadatastore.api import Document
 import metadatastore
 from mongoengine.connection import ConnectionError
 from pymongo.errors import AutoReconnect
+
+
+
+class WatchForHeadersModel(Atom):
+    """ Class that defines the model for a UI component that watches the
+    databroker for new scans
+
+    Attributes
+    ----------
+    auto_update : atom.Bool
+    update_rate : atom.Int
+        The rate at which the current header will be checked on the data broker
+    header_id : atom.Str
+    """
+    auto_update = Bool(False)
+    update_rate = Int(1000)
+    header = Typed(Document)
+    search_info = Str("No search performed")
+
+    def check_header(self):
+        try:
+            header = DataBroker[-1]
+        except IndexError:
+            self.search_info = "No runs found."
+            header = None
+            return
+        else:
+            self.search_info = "Run Found."
+        if (not self.header or self.header.ids['run_start_uid'] !=
+            header.ids['run_start_uid']):
+            self.header = header
+
+class DisplayHeaderModel(Atom):
+    """Class that defines the model for displaying header information
+
+    Attributes
+    ----------
+    selected : metadatastore.api.Document
+    """
+    header = Typed(Document)
+    selected_as_dict = Dict()
+    selected_keys = List()
+
+    def new_run_header(self, changed):
+        """Observer function for a new run header"""
+        self.header = changed['value']
+
+    @observe('header')
+    def header_changed(self, changed):
+        run_start_keys = {}
+        key_labels = [['KEY NAME', 'DATA LOCATION', 'PV NAME']]
+        run_start_dict = vars(self.header)
+        event_descriptors = run_start_dict.pop('event_descriptors', [])
+        data_keys = self._format_for_enaml(event_descriptors)
+        sample = run_start_dict.pop('sample', {})
+        beamline_config = run_start_dict.pop('beamline_config', {})
+
+        data_keys = sorted(data_keys, key=lambda x: x[0].lower())
+        run_start_keys = key_labels + data_keys
+
+        # set the summary dictionary
+        self.selected_as_dict = {}
+        self.selected_as_dict = run_start_dict
+        # set the keys dictionary
+        self.selected_keys = []
+        self.selected_keys = run_start_keys
+
+
+    def _format_for_enaml(self, event_descriptors):
+        """
+        Format the data keys into a single list that enaml will unpack into a
+        grid of N rows by 3 columns
+        """
+        data_keys = []
+        for evd in event_descriptors:
+            dk = evd.data_keys
+            for data_key, data_key_dict in six.iteritems(dk):
+                while data_key in data_keys:
+                    data_key += '_1'
+                print(data_key, data_key_dict)
+                name = data_key
+                src = data_key_dict['source']
+                loc = data_key_dict['external']
+                if loc is None:
+                    loc = 'metadatastore'
+                data_keys.append([name, loc, src])
+        return data_keys
 
 
 class GetLastModel(Atom):
@@ -20,35 +107,21 @@ class GetLastModel(Atom):
     selected : metadatastore.api.Document
     """
     num_to_retrieve = Range(low=1)
-    headers = List()
-    selected = Typed(Document)
-    selected_as_dict = Dict()
-    selected_keys = List()
-    summary_visible = Bool(False)
     search_info = Str()
+    headers = List()
     connection_is_active = Bool(False)
-    __run_starts_as_dict = Dict()
-    __run_starts_keys = Dict()
+    summary_visible = Bool(False)
+    header = Typed(Document)
 
     def __init__(self):
         with self.suppress_notifications():
-            self.selected = None
+            self.header = None
 
-
-    @observe('selected')
-    def selected_changed(self, changed):
-        # set the summary dictionary
-        self.selected_as_dict = {}
-        self.selected_as_dict = self.__run_starts_as_dict[self.selected]
-        # set the keys dictionary
-        self.selected_keys = []
-        self.selected_keys = self.__run_starts_keys[self.selected]
 
     @observe('num_to_retrieve')
     def num_changed(self, changed):
         try:
             self.headers = DataBroker[-self.num_to_retrieve:]
-            print('in num_changed in search/model.py. headers: {}'.format(self.headers))
         except ConnectionError:
             self.search_info = "Database [[{}]] not available on [[{}]]".format(
                 metadatastore.conf.mds_config['database'],
@@ -57,41 +130,13 @@ class GetLastModel(Atom):
             self.connection_is_active = False
             return
         except AutoReconnect:
-            self.search_info = "Connection to database [[{}]] on [[{}]] was lost".format(
-                metadatastore.conf.mds_config['database'],
-                metadatastore.conf.mds_config['host']
+            self.search_info = (
+                "Connection to database [[{}]] on [[{}]] was lost".format(
+                    metadatastore.conf.mds_config['database'],
+                    metadatastore.conf.mds_config['host']
+                )
             )
             self.connection_is_active = False
             return
-        run_starts_as_dict = {}
-        run_starts_keys = {}
-        header = [['KEY NAME', 'DATA LOCATION', 'PV NAME']]
-        for bre in self.headers:
-            bre_vars = vars(bre)
-            event_descriptors = bre_vars.pop('event_descriptors', [])
-            sample = bre_vars.pop('sample', {})
-            beamline_config = bre_vars.pop('beamline_config', {})
-            dct = bre_vars
-            run_starts_as_dict[bre] = dct
-            # format the data keys into a single list that enaml will unpack
-            # into a N rows by 3 columns grid
-            data_keys = []
-            for evd in event_descriptors:
-                dk = evd.data_keys
-                for data_key, data_key_dict in six.iteritems(dk):
-                    while data_key in data_keys:
-                        data_key += '_1'
-                    print(data_key, data_key_dict)
-                    name = data_key
-                    src = data_key_dict['source']
-                    loc = data_key_dict['external']
-                    if loc is None:
-                        loc = 'metadatastore'
-                    data_keys.append([name, loc, src])
-            data_keys = sorted(data_keys, key=lambda x: x[0].lower())
-            run_starts_keys[bre] = header + data_keys
         self.search_info = "Requested: {}. Found: {}".format(
             self.num_to_retrieve, len(self.headers))
-        self.__run_starts_as_dict = run_starts_as_dict
-        self.__run_starts_keys = run_starts_keys
-        self.connection_is_active = True

--- a/dataportal/replay/search/view.enaml
+++ b/dataportal/replay/search/view.enaml
@@ -4,10 +4,11 @@ import six
 
 from enaml.widgets.api import (Container, RadioButton, PushButton, Window,
                                ScrollArea, Form, Label, GroupBox, SpinBox,
-                               Html, Field)
+                               Html, Field, Timer)
 from enaml.core.api import (Looper, Conditional, Include)
 from enaml.stdlib.fields import IntField
 from enaml.layout.api import (vbox, hbox, spacer, Box, grid, factory, align)
+from ..core import TimerButton
 
 
 def generate_grid(container, num_cols):
@@ -42,18 +43,49 @@ enamldef DisplaySummary(Container):
                 read_only = True
 
 
+enamldef WatchForHeadersView(Container):
+    """Enaml definition for the widget that displays the controls for
+    how frequently databroker will be asked for its most recent header
+    """
+    attr watch_headers_model
+
+    Container:
+        padding = Box(0, 0, 0, 0)
+        constraints = [vbox(hbox(refresh_button, update_input),
+                            search_info)]
+        Timer: the_timer:
+            interval << watch_headers_model.update_rate
+            single_shot = False
+            timeout ::
+                watch_headers_model.check_header()
+        TimerButton: refresh_button:
+            checked := watch_headers_model.auto_update
+            timer = the_timer
+            text = "Automatically update data"
+        SpinBox: update_input:
+            minimum = 1000
+            maximum = 3600000
+            #special_value_text = 'Autotune'
+            value := watch_headers_model.update_rate
+            suffix = ' ms'
+            single_step << value / 100
+        Label: search_info:
+            text << watch_headers_model.search_info
+
+
 enamldef GetLastView(Container):
     """Enaml definition for the widget that displays the controls for
     searching the dataportal for the last N runs
     """
     attr muxer_model
+    attr display_header_model
     attr get_last_model
     Container:
         padding = Box(0, 0, 0, 0)
         constraints = [vbox(hbox(num_runs, select_run),
                             search_info,
-                            headers,
-                            run_summary)]
+                            headers)]
+
         # GUI element that selects the number of run headers to display
         SpinBox: num_runs:
             prefix = "Display "
@@ -65,7 +97,7 @@ enamldef GetLastView(Container):
             text = "Show data for selected run"
             enabled << get_last_model.connection_is_active
             clicked ::
-                muxer_model.run_header = get_last_model.selected
+                get_last_model.header = get_last_model.selected
         # GUI element that provides search stats
         Label: search_info:
             text << get_last_model.search_info
@@ -74,20 +106,24 @@ enamldef GetLastView(Container):
             Looper:
                 iterable << get_last_model.headers
                 RadioButton:
-                    text = '{}: {}'.format(loop_item.scan_id,
-                                           loop_item.start_datetime)
+                    text = '{}: {}'.format(
+                        loop_item.scan_id, loop_item.start_datetime)
                     clicked ::
-                        get_last_model.summary_visible = True
-                        get_last_model.selected = loop_item
+                        display_header_model.selected = loop_item
+
+enamldef DisplayHeaderView(Container):
+    attr display_header_model
+    Container:
+        padding = Box(0, 0, 0, 0)
         # GUI Element to show a Run Summary and the corresponding Data Keys
         GroupBox: run_summary:
-            visible := get_last_model.summary_visible
+            #visible := get_last_model.summary_visible
             padding = Box(0, 0, 0, 0)
             title = "Run Summary"
             flat = True
             DisplaySummary:
                 padding = Box(0, 0, 0, 0)
-                display_dict << get_last_model.selected_as_dict
+                display_dict << display_header_model.selected_as_dict
             GroupBox:
                 padding = Box(0, 0, 0, 0)
                 title = "Data Key Information"
@@ -96,7 +132,7 @@ enamldef GetLastView(Container):
                     padding = Box(0, 0, 0, 0)
                     constraints << [factory(generate_grid, 3)]
                     Include:
-                        objects << gen_objects(get_last_model.selected_keys)
+                        objects << gen_objects(display_header_model.selected_keys)
 
 def gen_objects(keys):
     try:


### PR DESCRIPTION
- Typing 'replay' will launch the GUI in a non-auto-data-grabbing
  way.
- Typing 'replay --ophyd' will launch the GUI in a way that will
  automatically be watching for the latest header and plot the data.
- Also refactored the search and results display
