### PR TITLE
BLD: Make Travis builds faster by using more conda, less pip.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,17 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda --yes
-  - conda config --add channels soft-matter
-  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas scikit-image pims h5py matplotlib
+  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas scikit-image h5py matplotlib coverage
+  # Dependencies not in official conda have been uploaded to binstar orgs.
+  - conda install -n testenv --yes -c soft-matter pims 
+  - conda install -n testenv --yes -c nikea mongoengine
+  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install -n testenv --yes enaml; fi'
+  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install -n testenv --yes atom; fi'
   - source activate testenv
   - 'pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'
   - 'pip install https://github.com/NSLS-II/channelarchiver/zipball/master#egg=channelarchiver'
   - 'pip install https://github.com/Nikea/scikit-xray/zipball/master#egg=scikit-xray'
-  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install https://github.com/Nucleic/enaml/zipball/master#enaml; fi'
-  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install https://github.com/Nucleic/atom/zipball/master#atom; fi'
-  - pip install coveralls mongoengine
   - python setup.py install
 
 


### PR DESCRIPTION
- enaml and atom are available through official conda
- mongoengine builds have been copied to the Nikea channel. This change does not introduce dependency on a dev user's account.
