### PR TITLE
Add EventQueue in broker for efficient extraction of live-updating data

### DIFF
--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,4 +1,4 @@
-from .simple_broker import DataBroker
+from .simple_broker import DataBroker, EventQueue
 from .handler_registration import register_builtin_handlers
 
 DataBroker = DataBroker()  # singleton

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -185,7 +185,7 @@ class EventQueue(object):
         for header in self.headers:
             header = copy.copy(header)
             header.id = header.run_start_id
-            events_by_descriptor.extend(find_event(header))
+            events_by_descriptor.extend(find_events(header))
         events = [event for descriptor in events_by_descriptor
                   for event in descriptor]
 

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -164,7 +164,7 @@ class EventQueue(object):
     queue = EventQueue(header)
     while True:
         queue.update()
-        new_events = queue.pop()
+        new_events = queue.get()
         # Do something with them, such as dm.append_events(new_events)
     """
 
@@ -200,7 +200,7 @@ class EventQueue(object):
         [fill_event(event) for event in new_events]
         self._queue.append(new_events)  # the entry can be an empty list
 
-    def pop(self):
+    def get(self):
         """
         Get a list of new Events.
 

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -208,7 +208,10 @@ class EventQueue(object):
         discovered in the same call to update().
         """
         # EventQueue is FIFO.
-        return self._queue.popleft()
+        try:
+            return self._queue.popleft()
+        except IndexError:
+            return []
 
 
 class LocationError(ValueError):

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -169,7 +169,8 @@ class EventQueue(object):
     """
 
     def __init__(self, headers):
-        if not isinstance(headers, Iterable):
+        if hasattr(headers, 'keys'):
+            # This is some kind of dict.
             headers = [headers]
         self.headers = headers
         self._known_ids = set()
@@ -206,6 +207,7 @@ class EventQueue(object):
         Each call returns a (maybe empty) list of Events that were
         discovered in the same call to update().
         """
+        # EventQueue is FIFO.
         return self._queue.popleft()
 
 

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -60,13 +60,13 @@ class DataBroker(object):
         return result
 
     @classmethod
-    def fetch_events(cls, runs, ca_host=None, channels=None):
+    def fetch_events(cls, headers, ca_host=None, channels=None):
         """
         Get Events from given run(s).
 
         Parameters
         ----------
-        runs : one RunHeader or a list of them
+        headers : one RunHeader or a list of them
         ca_host : URL string
             the URL of your archiver's ArchiveDataServer.cgi. For example,
             'http://cr01arc01/cgi-bin/ArchiveDataServer.cgi'
@@ -81,15 +81,15 @@ class DataBroker(object):
         data : a flat list of Event objects
         """
         try:
-            runs.items()
+            headers.items()
         except AttributeError:
             pass
         else:
-            runs = [runs]
+            headers = [headers]
 
         events = []
-        for run in runs:
-            descriptors = find_event_descriptors(run_start_id=run.run_start_id)
+        for header in headers:
+            descriptors = find_event_descriptors(run_start_id=header.run_start_id)
             for descriptor in descriptors:
                 events.extend(find_events(descriptor=descriptor))
         [fill_event(event) for event in events]
@@ -182,13 +182,13 @@ class EventQueue(object):
         """Obtain a fresh list of the relevant Events."""
 
         # like fetch_events, but we don't fill in the data right away
-        events_by_descriptor = []
+        events = []
         for header in self.headers:
-            header = copy.copy(header)
-            header.id = header.run_start_id
-            events_by_descriptor.extend(find_events(header))
-        events = [event for descriptor in events_by_descriptor
-                  for event in descriptor]
+            descriptors = find_event_descriptors(run_start_id=header.run_start_id)
+            for descriptor in descriptors:
+                events.extend(find_events(descriptor=descriptor))
+        if not events:
+            return
 
         new_events = []
         for event in events:

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -184,7 +184,7 @@ class EventQueue(object):
         events_by_descriptor = []
         for header in self.headers:
             header = copy.copy(header)
-            header.id = header.ids['run_start_id']
+            header.id = header.run_start_id
             events_by_descriptor.extend(find_event(header))
         events = [event for descriptor in events_by_descriptor
                   for event in descriptor]

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -82,28 +82,28 @@ def test_event_queue():
                           beamline_config=insert_beamline_config({}, time=0.))
     header = db.find_headers(scan_id=scan_id)
     queue = EventQueue(header)
-    # Queue should be empty until we update.
-    f = lambda: queue.pop()
-    assert_raises(IndexError, f)
+    # Queue should be empty until we create Events.
+    empty_bundle = queue.get()
+    assert_equal(len(empty_bundle), 0)
     queue.update()
-    # This should add an empty list to the queue.
-    empty_bundle = queue.pop()
+    empty_bundle = queue.get()
     assert_equal(len(empty_bundle), 0)
     events = temperature_ramp.run(rs)
     # This should add a bundle of Events to the queue.
     queue.update()
-    first_bundle = queue.pop()
+    first_bundle = queue.get()
     assert_equal(len(first_bundle), len(events))
     more_events = temperature_ramp.run(rs)
     # Queue should be empty until we update.
-    assert_raises(IndexError, f)
+    empty_bundle = queue.get()
+    assert_equal(len(empty_bundle), 0)
     queue.update()
-    second_bundle = queue.pop()
+    second_bundle = queue.get()
     assert_equal(len(second_bundle), len(more_events))
     # Add Events from a different example into the same Header.
     other_events = image_and_scalar.run(rs)
     queue.update()
-    third_bundle = queue.pop()
+    third_bundle = queue.get()
     assert_equal(len(third_bundle), len(other_events))
 
 

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -13,7 +13,8 @@ import pandas as pd
 from .. import sources
 from ..sources import channelarchiver as ca
 from ..sources import switch
-from ..broker import DataBroker as db
+from ..broker import EventQueue, DataBroker as db
+from ..examples.sample_data import temperature_ramp, image_and_scalar
 
 from nose.tools import make_decorator
 from nose.tools import (assert_equal, assert_raises, assert_true,
@@ -23,25 +24,24 @@ from nose.tools import (assert_equal, assert_raises, assert_true,
 from metadatastore.odm_templates import (BeamlineConfig, EventDescriptor,
                                          Event, RunStart, RunStop)
 from metadatastore.api import insert_run_start, insert_beamline_config
-from filestore.utils.testing import fs_setup, fs_teardown
 from metadatastore.utils.testing import mds_setup, mds_teardown
-from ..examples.sample_data import temperature_ramp, image_and_scalar
+from filestore.utils.testing import fs_setup, fs_teardown
 logger = logging.getLogger(__name__)
 
-db_name = str(uuid.uuid4())
-conn = None
+
 blc = None
 
 
 def setup():
-    fs_setup()
     mds_setup()
+    fs_setup()
     blc = insert_beamline_config({}, ttime.time())
 
     switch(channelarchiver=False)
     start, end = '2015-01-01 00:00:00', '2015-01-01 00:01:00'
     simulated_ca_data = generate_ca_data(['ch1', 'ch2'], start, end)
     ca.insert_data(simulated_ca_data)
+
     owners = ['docbrown', 'nedbrainard']
     num_entries = 5
     for owner in owners:
@@ -63,6 +63,10 @@ def teardown():
 
 
 def test_basic_usage():
+    for i in range(5):
+        insert_run_start(time=float(i), scan_id=i + 1,
+                         owner='nedbrainard', beamline_id='example',
+                         beamline_config=insert_beamline_config({}, time=0.))
     header_1 = db[-1]
     header_ned = db.find_headers(owner='nedbrainard')
     header_null = db.find_headers(owner='this owner does not exist')
@@ -71,7 +75,43 @@ def test_basic_usage():
     events_null = db.fetch_events(header_null)
 
 
+def test_event_queue():
+    scan_id = np.random.randint(1e12)  # unique enough for government work
+    rs = insert_run_start(time=0., scan_id=scan_id,
+                          owner='queue-tester', beamline_id='example',
+                          beamline_config=insert_beamline_config({}, time=0.))
+    header = db.find_headers(scan_id=scan_id)
+    queue = EventQueue(header)
+    # Queue should be empty until we update.
+    f = lambda: queue.pop()
+    assert_raises(IndexError, f)
+    queue.update()
+    # This should add an empty list to the queue.
+    empty_bundle = queue.pop()
+    assert_equal(len(empty_bundle), 0)
+    events = temperature_ramp.run(rs)
+    # This should add a bundle of Events to the queue.
+    queue.update()
+    first_bundle = queue.pop()
+    assert_equal(len(first_bundle), len(events))
+    more_events = temperature_ramp.run(rs)
+    # Queue should be empty until we update.
+    assert_raises(IndexError, f)
+    queue.update()
+    second_bundle = queue.pop()
+    assert_equal(len(second_bundle), len(more_events))
+    # Add Events from a different example into the same Header.
+    other_events = image_and_scalar.run(rs)
+    queue.update()
+    third_bundle = queue.pop()
+    assert_equal(len(third_bundle), len(other_events))
+
+
 def test_indexing():
+    for i in range(5):
+        insert_run_start(time=float(i), scan_id=i + 1,
+                         owner='nedbrainard', beamline_id='example',
+                         beamline_config=insert_beamline_config({}, time=0.))
     header = db[-1]
     is_list = isinstance(header, list)
     assert_false(is_list)
@@ -131,6 +171,14 @@ def test_indexing():
 
 
 def test_lookup():
+    for i in range(5):
+        insert_run_start(time=float(i), scan_id=i + 1,
+                         owner='docbrown', beamline_id='example',
+                         beamline_config=insert_beamline_config({}, time=0.))
+    for i in range(5):
+        insert_run_start(time=float(i), scan_id=i + 1,
+                         owner='nedbrainard', beamline_id='example',
+                         beamline_config=insert_beamline_config({}, time=0.))
     header = db[3]
     scan_id = header.scan_id
     owner = header.owner


### PR DESCRIPTION
The EventQueue knows about a Header (or Headers) and it can query it for an updated full list of Events. It keeps tracks of which Events it has already seen, and it only gets the filestore payload once per Event.

Here's an example of using an EventQueue with a DataMuxer to keep it up to date.

```
from dataportal.broker import DataBroker, EventQueue
from dataportal.muxer import DataMuxer

dm = DataMuxer()
header = DataBroker[-1]
queue = EventQueue(header)
while True:
    queue.update()
    new_events = queue.pop()
    dm.append_events(new_events)
    # update a plot or something
```

This PR includes a thorough test.
