### PR TITLE
MNT: Give the 'val' column a more interesting name

### DIFF
--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -119,7 +119,7 @@ class ColSpec(namedtuple(
 
 def _validate_upsample(input):
     # TODO The upsampling method could be any callable.
-    if input is None:
+    if input is None or input == 'None':
         return 'None'
     if not (input in ColSpec.upsampling_methods):
         raise ValueError("{} is not a valid upsampling method. It "
@@ -448,7 +448,7 @@ class DataMuxer(object):
                 upsample = col_info.upsample
             else:
                 upsample = _validate_upsample(upsample)
-            if ((upsample is not None) or (upsample != 'None')) and (col_info.ndim > 0):
+            if not (upsample is None or upsample == 'None') and (col_info.ndim > 0):
                 raise NotImplementedError(
                     "Only scalar data can be upsampled. "
                     "The {0}-dimensional source {1} was given the upsampling "
@@ -462,9 +462,9 @@ class DataMuxer(object):
 
             # Start by using the first point in a bin. (If there are actually
             # multiple points, we will either overwrite or raise below.)
-            val_name = 'value: {}'.format(downsample)
+            val_name = downsample
             if val_name is None or val_name == 'None':
-                val_name = 'value: raw'
+                val_name = 'raw'
             result[name][val_name] = first_point[name]
 
             # Short-circuit if we are done.

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -497,7 +497,7 @@ class DataMuxer(object):
                                                 index=safe_bins)
                 logger.debug("Interpolating to fill %d of %d empty bins in %s",
                              len(safe_bins), has_no_points[name].sum(), name)
-                val_col_name += '_{}'.format(upsample[:4])
+                val_col_name += '_{}'.format(upsample)
                 val_col_series.fillna(interpolated_points, inplace=True)
 
             # Short-circuit if we are done.
@@ -508,7 +508,7 @@ class DataMuxer(object):
 
             # append the downsample method to the value column name,
             # but keep it short
-            val_col_name += '_{}'.format(six.text_type(downsample)[:4])
+            val_col_name += '_{}'.format(six.text_type(downsample))
 
             # Multi-valued bins must be downsampled (reduced). If there is no
             # rule for downsampling, we have no recourse: we must raise.

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -462,7 +462,10 @@ class DataMuxer(object):
 
             # Start by using the first point in a bin. (If there are actually
             # multiple points, we will either overwrite or raise below.)
-            result[name]['val'] = first_point[name]
+            val_name = 'value: {}'.format(downsample)
+            if val_name is None or val_name == 'None':
+                val_name = 'value: raw'
+            result[name][val_name] = first_point[name]
 
             # Short-circuit if we are done.
             if np.all(has_one_point[name]):
@@ -492,7 +495,7 @@ class DataMuxer(object):
                                                 index=safe_bins)
                 logger.debug("Interpolating to fill %d of %d empty bins in %s",
                              len(safe_bins), has_no_points[name].sum(), name)
-                result[name]['val'].fillna(interpolated_points, inplace=True)
+                result[name][val_name].fillna(interpolated_points, inplace=True)
 
             # Short-circuit if we are done.
             if np.all(~has_multiple_points[name]):
@@ -530,7 +533,7 @@ class DataMuxer(object):
                     lambda x: np.max(np.asarray(x.dropna()), 0))
                 result[name]['min'] = g.apply(
                     lambda x: np.min(np.asarray(x.dropna()), 0))
-            result[name]['val'].where(~has_multiple_points[name], downsampled,
+            result[name][val_name].where(~has_multiple_points[name], downsampled,
                                       inplace=True)
 
         result = pd.concat(result, axis=1)  # one MultiIndexed DataFrame

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -460,18 +460,20 @@ class DataMuxer(object):
             else:
                 downsample = _validate_downsample(downsample)
 
+            # init the name and series for the column that holds information
+            # pertaining to the measured data
+            val_col_name = 'val'
             # Start by using the first point in a bin. (If there are actually
             # multiple points, we will either overwrite or raise below.)
-            val_name = downsample
-            if val_name is None or val_name == 'None':
-                val_name = 'raw'
-            result[name][val_name] = first_point[name]
+            val_col_series = pd.Series(data=first_point[name])
 
             # Short-circuit if we are done.
             if np.all(has_one_point[name]):
+                val_col_name += '_raw'
+                result[name][val_col_name] = val_col_series
                 continue
 
-            result[name]['count'] = counts[name]
+            count_series = counts[name]
 
             # If any bin has no data, use the upsampling rule to interpolate
             # at the center of the empty bins. If there is no rule, simply
@@ -495,11 +497,18 @@ class DataMuxer(object):
                                                 index=safe_bins)
                 logger.debug("Interpolating to fill %d of %d empty bins in %s",
                              len(safe_bins), has_no_points[name].sum(), name)
-                result[name][val_name].fillna(interpolated_points, inplace=True)
+                val_col_name += '_{}'.format(upsample[:4])
+                val_col_series.fillna(interpolated_points, inplace=True)
 
             # Short-circuit if we are done.
             if np.all(~has_multiple_points[name]):
+                result[name][val_col_name] = val_col_series
+                result[name]['count'] = count_series
                 continue
+
+            # append the downsample method to the value column name,
+            # but keep it short
+            val_col_name += '_{}'.format(six.text_type(downsample)[:4])
 
             # Multi-valued bins must be downsampled (reduced). If there is no
             # rule for downsampling, we have no recourse: we must raise.
@@ -516,9 +525,9 @@ class DataMuxer(object):
             if col_info.ndim == 0:
                 # For scalars, pandas knows what to do.
                 downsampled = g.agg(downsample)
-                result[name]['std'] = g.std()
-                result[name]['max'] = g.max()
-                result[name]['min'] = g.min()
+                std_series = g.std()
+                max_series = g.max()
+                min_series = g.min()
             else:
                 # For nonscalars, we are abusing groupby and must go to a
                 # a little more trouble to guarantee success.
@@ -527,14 +536,16 @@ class DataMuxer(object):
                     # in the call to resample.
                     downsample = ColSpec._downsample_mapping[downsample]
                 downsampled = g.apply(lambda x: downsample(np.asarray(x.dropna())))
-                result[name]['std'] = g.apply(
-                    lambda x: np.std(np.asarray(x.dropna()), 0))
-                result[name]['max'] = g.apply(
-                    lambda x: np.max(np.asarray(x.dropna()), 0))
-                result[name]['min'] = g.apply(
-                    lambda x: np.min(np.asarray(x.dropna()), 0))
-            result[name][val_name].where(~has_multiple_points[name], downsampled,
-                                      inplace=True)
+                std_series = g.apply(lambda x: np.std(np.asarray(x.dropna()), 0))
+                max_series = g.apply(lambda x: np.max(np.asarray(x.dropna()), 0))
+                min_series = g.apply(lambda x: np.min(np.asarray(x.dropna()), 0))
+
+            val_col_series.where(~has_multiple_points[name], downsampled, inplace=True)
+            result[name][val_col_name] = val_col_series
+            result[name]['count'] = count_series
+            result[name]['std'] = std_series
+            result[name]['max'] = max_series
+            result[name]['min'] = min_series
 
         result = pd.concat(result, axis=1)  # one MultiIndexed DataFrame
         # Label the bins with time points.

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -104,8 +104,12 @@ class CommonBinningTests(object):
         first = self.dm[self.sparse].first_valid_index()
         last = self.dm[self.sparse].last_valid_index()
         expected_len = 2 + len(self.dm[self.dense].loc[first:last])
-        self.assertLess(result1[self.sparse]['val'].count(), expected_len)
-        self.assertEqual(result2[self.sparse]['val'].count(), expected_len)
+        # print('result1 columns: {}'.format(result1[self.sparse].columns))
+        # print('result2 columns: {}'.format(result2[self.sparse].columns))
+        res1 = result1[self.sparse][result1[self.sparse].columns[0]]
+        res2 = result2[self.sparse][result2[self.sparse].columns[0]]
+        self.assertLess(res1.count(), expected_len)
+        self.assertEqual(res2.count(), expected_len)
 
         # There should not be stats columns.
         self.assertFalse('max' in result1[self.dense].columns)


### PR DESCRIPTION
1. I have no idea how much stuff this is going to break... All the tests seem to pass (locally at least), so that's a good sign
2. @danielballan I'm not necessarily suggesting that this should be the final iteration, but I think this is an interesting discussion point.  'val' is a non-descriptive term and I think that the dataframe that results from the `bin_on` operation would be more informative if the 'val' column name reflected the downsampling mechanism. 
3. See this notebook for the output of the bin_on dataframe: http://nbviewer.ipython.org/gist/anonymous/a88b0410a54cb0a71fce
