### PR TITLE
Fix _dataframe sparseness

### DIFF
--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -233,14 +233,13 @@ class DataMuxer(object):
         self._stale = True
         if event.descriptor.id not in self._known_descriptors:
             self._process_new_descriptor(event.descriptor)
-        for name, data_dict in event.data.items():
-            # Both scalar and nonscalar data will get stored in the DataFrame.
-            # This may be optimized later, but it might not actually help much.
-            self._data.append(
-                {name: data[0] for name, data in event.data.items()})
-            self._timestamps.append(
-                {name: data[1] for name, data in event.data.itmes()})
-            self._time.append(event.time)
+        # Both scalar and nonscalar data will get stored in the DataFrame.
+        # This may be optimized later, but it might not actually help much.
+        self._data.append(
+            {name: data[0] for name, data in event.data.items()})
+        self._timestamps.append(
+            {name: data[1] for name, data in event.data.items()})
+        self._time.append(event.time)
         return True
 
     def _process_new_descriptor(self, descriptor):

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -236,14 +236,14 @@ class DataMuxer(object):
         # Both scalar and nonscalar data will get stored in the DataFrame.
         # This may be optimized later, but it might not actually help much.
         self._data.append(
-            {name: data[0] for name, data in event.data.items()})
+            {name: data[0] for name, data in six.iteritems(event.data)})
         self._timestamps.append(
-            {name: data[1] for name, data in event.data.items()})
+            {name: data[1] for name, data in six.iteritems(event.data)})
         self._time.append(event.time)
         return True
 
     def _process_new_descriptor(self, descriptor):
-        for name, description in descriptor.data_keys.items():
+        for name, description in six.iteritems(descriptor.data_keys):
 
             # If we already have this source name, the unique source
             # identifiers must match. Ambiguous names are not allowed.
@@ -584,7 +584,7 @@ class DataMuxer(object):
     @property
     def col_info_by_ndim(self):
         result = {}
-        for name, col_spec in self.col_info.items():
+        for name, col_spec in six.iteritems(self.col_info):
             try:
                 result[col_spec.ndim]
             except KeyError:

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -236,8 +236,10 @@ class DataMuxer(object):
         for name, data_dict in event.data.items():
             # Both scalar and nonscalar data will get stored in the DataFrame.
             # This may be optimized later, but it might not actually help much.
-            self._data.append({name: event.data[name][0]})
-            self._timestamps.append({name: event.data[name][1]})
+            self._data.append(
+                {name: data[0] for name, data in event.data.items()})
+            self._timestamps.append(
+                {name: data[1] for name, data in event.data.itmes()})
             self._time.append(event.time)
         return True
 

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -470,6 +470,7 @@ class DataMuxer(object):
 
             # Short-circuit if we are done.
             if np.all(has_one_point[name]):
+                logger.debug("%s has exactly one data point per bin", name)
                 val_col_name += '_raw'
                 result[name][val_col_name] = val_col_series
                 continue
@@ -503,6 +504,7 @@ class DataMuxer(object):
 
             # Short-circuit if we are done.
             if np.all(~has_multiple_points[name]):
+                logger.debug("%s has at least one data point per bin", name)
                 result[name][val_col_name] = val_col_series
                 result[name]['count'] = count_series
                 continue
@@ -524,6 +526,7 @@ class DataMuxer(object):
 
             g = grouped[name]  # for brevity
             if col_info.ndim == 0:
+                logger.debug("The scalar column %s must be downsampled.", name)
                 # For scalars, pandas knows what to do.
                 downsampled = g.agg(downsample)
                 std_series = g.std()
@@ -532,6 +535,8 @@ class DataMuxer(object):
             else:
                 # For nonscalars, we are abusing groupby and must go to a
                 # a little more trouble to guarantee success.
+                logger.debug("The nonscalar column %s must be downsampled.",
+                             name)
                 if not callable(downsample):
                     # Do this lookup here so that strings can be passed
                     # in the call to resample.

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -15,6 +15,7 @@ from metadatastore.api import insert_run_start, insert_beamline_config
 import time as ttime
 from nose.tools import (assert_equal, assert_raises, assert_true,
                         assert_false)
+from numpy.testing.utils import assert_array_equal
 
 def setup():
     fs_setup()
@@ -152,3 +153,20 @@ class TestImageAndScalar(unittest.TestCase):
 
     def setUp(self):
         self.dm = DataMuxer.from_events(image_and_scalar.run())
+
+    def test_index_is_unique(self):
+        self.assertTrue(self.dm._dataframe.index.is_unique)
+
+    def test_bin_on_image(self):
+        binned = self.dm.bin_on('img', agg={'Tsam': 'mean'})
+        self.assertEqual(len(binned), len(self.dm['img']))
+
+    def test_image_shape(self):
+        datapoint = self.dm['img'].values[2]
+        self.assertEqual(datapoint.ndim, 2)
+
+        binned = self.dm.bin_on('img', agg={'Tsam': 'mean'})
+        binned_datapoint = binned['img']['val_raw'].values[2]
+        self.assertEqual(binned_datapoint.ndim, 2)
+
+        assert_array_equal(datapoint, binned_datapoint)

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -85,6 +85,10 @@ class CommonBinningTests(object):
         # There should be stats columns.
         self.assertTrue('max' in result[self.dense].columns)
 
+        # There should be one row per bin.
+        self.assertTrue(self.dm._dataframe.index.is_unique)
+        self.assertTrue(result.index.is_unique)
+
     def test_bin_on_dense(self):
         "Align a sparse column to a dense column"
 
@@ -118,6 +122,10 @@ class CommonBinningTests(object):
         self.assertFalse('count' in result1[self.dense].columns)
         # But the sparse column should.
         self.assertTrue('count' in result1[self.sparse].columns)
+
+        # There should be one row per bin.
+        self.assertTrue(result1.index.is_unique)
+        self.assertTrue(result2.index.is_unique)
 
 
 class TestBinningTwoScalarEvents(CommonBinningTests, unittest.TestCase):


### PR DESCRIPTION
The muxer's internal `_dataframe` as not being built properly. Data keys belonging to the same Event should go into a single row, not separate rows. This fixes that and adds several tests.
