### PR TITLE
ENH: Allow DataBroker['(parital) uid string']

### DIFF
--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -24,7 +24,7 @@ class DataBroker(object):
     @classmethod
     def __getitem__(cls, key):
         if isinstance(key, slice):
-            # Slice on recent runs.
+            # Interpret key as a slice into previous scans.
             if key.start is not None and key.start > -1:
                 raise ValueError("Slices must be negative. The most recent "
                                  "run is referred to as -1.")
@@ -43,6 +43,7 @@ class DataBroker(object):
             header = [Header.from_run_start(h) for h in result]
         elif isinstance(key, int):
             if key > -1:
+                # Interpret key as a scan_id.
                 gen = find_run_starts(scan_id=key)
                 try:
                     result = next(gen)  # most recent match
@@ -50,6 +51,7 @@ class DataBroker(object):
                     raise ValueError("No such run found.")
                 header = Header.from_run_start(result)
             else:
+                # Interpret key as the Nth last scan.
                 gen = find_last(-key)
                 for i in range(-key):
                     try:
@@ -58,12 +60,31 @@ class DataBroker(object):
                         raise IndexError(
                             "There are only {0} runs.".format(i))
                 header = Header.from_run_start(result)
+        elif isinstance(key, six.string_types):
+            # Interpret key as a uid (or the few several characters of one).
+            if len(key) == 36:
+                # key is a complete uid
+                query = dict(uid=key)
+            else:
+                # key is a truncated uid; use regex
+                query = dict(uid={'$regex': '{0}.*'.format(key)})
+            results = list(find_run_starts(**query))
+            if len(results) < 1:
+                raise ValueError("No such run found.")
+            if len(results) > 1:
+                raise ValueError("That partial uid matches multiple runs. "
+                                 "Provide more characters.")
+            result, = results
+            header = Header.from_run_start(result)
         elif isinstance(key, Iterable):
+            # Interpret key as a list of several keys. If it is a string
+            # we will never get this far.
             return [cls.__getitem__(k) for k in key]
         else:
             raise ValueError("Must give an integer scan ID like [6], a slice "
                              "into past scans like [-5], [-5:], or [-5:-9:2], "
-                             "or a list like [1, 7, 13].")
+                             "a list like [1, 7, 13], or a (partial) uid "
+                             "like ['a23jslk'].")
         return header
 
     @classmethod
@@ -422,3 +443,5 @@ class Stream(object):
 
 class IntegrityError(Exception):
     pass
+
+

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -62,13 +62,12 @@ class DataBroker(object):
                 header = Header.from_run_start(result)
         elif isinstance(key, six.string_types):
             # Interpret key as a uid (or the few several characters of one).
-            if len(key) == 36:
-                # key is a complete uid
-                query = dict(uid=key)
-            else:
-                # key is a truncated uid; use regex
-                query = dict(uid={'$regex': '{0}.*'.format(key)})
-            results = list(find_run_starts(**query))
+            # First try searching as if we have the full uid.
+            results = list(find_run_starts(uid=key))
+            if len(results) == 0:
+                # No dice? Try searching as if we have a partial uid.
+                gen = find_run_starts(uid={'$regex': '{0}.*'.format(key)})
+                results = list(gen)
             if len(results) < 1:
                 raise ValueError("No such run found.")
             if len(results) > 1:

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -171,7 +171,7 @@ def test_indexing():
     assert_equal(scan_ids, [3, 1, 2])
 
 
-def test_lookup():
+def test_scan_id_lookup():
     for i in range(5):
         insert_run_start(time=float(i), scan_id=i + 1,
                          owner='docbrown', beamline_id='example',
@@ -187,6 +187,26 @@ def test_lookup():
     # This should be the most *recent* Scan 3. There is ambiguity.
     assert_equal(owner, 'nedbrainard')
 
+def test_uid_lookup():
+    uid = str(uuid.uuid4())
+    uid2 = uid[0] + str(uuid.uuid4())[1:]  # same first character as uid
+    rs1 = insert_run_start(time=100., scan_id=1, uid=uid,
+                           owner='drstrangelove', beamline_id='example',
+                           beamline_config=insert_beamline_config({}, time=0.))
+    rs2 = insert_run_start(time=100., scan_id=1, uid=uid2,
+                           owner='drstrangelove', beamline_id='example',
+                           beamline_config=insert_beamline_config({}, time=0.))
+    # using full uid
+    actual_uid = db[uid].run_start_uid
+    assert_equal(actual_uid, uid)
+
+    # using first 6 chars
+    actual_uid = db[uid[:6]].run_start_uid
+    assert_equal(actual_uid, uid)
+
+    # using first char (will error)
+    f = lambda: db[uid[0]]
+    assert_raises(ValueError, f)
 
 def test_data_key():
     rs1 = insert_run_start(time=100., scan_id=1,


### PR DESCRIPTION
As suggested by @pavoljuhas, you can search for `<Header scan_id=1 run_start_uid='d4b78e8b-a23d-4d79-8c9a-3531a86a84d8'>` by its uid string or the first few characters of that string.

```
In [3]: DataBroker['d4b78e']
Out[3]: <Header scan_id=1 run_start_uid='d4b78e8b-a23d-4d79-8c9a-3531a86a84d8'>
```

If a given partial string is not specific enough, it raises informatively.

```
In [4]: DataBroker['e']
ValueError: That partial uid matches multiple runs. Provide more characters.
```

Closes #130 
