### PR TITLE
DataMuxer, revisited

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 services:
   - mongodb

--- a/dataportal/__init__.py
+++ b/dataportal/__init__.py
@@ -5,3 +5,6 @@ from .sources import *
 
 logger = logging.getLogger(__name__)
 __version__ = 'v0.0.5.post0'
+
+from .broker import DataBroker
+from .muxer import DataMuxer

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -561,7 +561,7 @@ class DataMuxer(object):
         return result
 
     def __getitem__(self, source_name):
-        if source_name not in self.col_info.keys() + ['time']:
+        if source_name not in list(self.col_info.keys()) + ['time']:
             raise KeyError("No data from a source called '{0}' has been "
                            "added.".format(source_name))
         # Unlike output from binning functions, this is indexed

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -307,7 +307,7 @@ class DataMuxer(object):
                 col_name = _timestamp_col_name(source_name)
                 df[col_name] = timestamps[source_name]
                 logger.debug("Including %s timestamps as data", source_name)
-            self._df = df.sort('time')
+            self._df = df.sort('time').reset_index(drop=True)
             self._stale = False
         return self._df
 

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -292,14 +292,14 @@ class DataMuxer(object):
     def _dataframe(self):
         # Rebuild the DataFrame if more data has been added.
         if self._stale:
-            self._df = pd.DataFrame(list(self._data), index)
+            self._df = pd.DataFrame(list(self._data))
             self._df['time'] = pd.to_datetime(list(self._time), unit='s')
             if self._timestamps_as_data:
                 # Only build this if we need it.
                 # TODO: We shouldn't have to build
                 # the whole thing, but there is already a lot of trickiness
                 # here so we'll worry about optimization later.
-                timestamps = pd.DataFrame(list(self._timestamps), index)
+                timestamps = pd.DataFrame(list(self._timestamps))
             for source_name in self._timestamps_as_data:
                 col_name = _timestamp_col_name(source_name)
                 self._df[col_name] = pd.to_datetime(timestamps[source_name],

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -293,7 +293,7 @@ class DataMuxer(object):
         # Rebuild the DataFrame if more data has been added.
         if self._stale:
             self._df = pd.DataFrame(list(self._data), index)
-            self._df['time'] = list(self._time)
+            self._df['time'] = pd.to_datetime(list(self._time), unit='s')
             if self._timestamps_as_data:
                 # Only build this if we need it.
                 # TODO: We shouldn't have to build
@@ -302,7 +302,8 @@ class DataMuxer(object):
                 timestamps = pd.DataFrame(list(self._timestamps), index)
             for source_name in self._timestamps_as_data:
                 col_name = _timestamp_col_name(source_name)
-                self._df[col_name] = timestamps[source_name]
+                self._df[col_name] = pd.to_datetime(timestamps[source_name],
+                                                    unit='s')
                 logger.debug("Including %s timestamps as data", source_name)
             self._stale = False
         return self._df

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -465,6 +465,9 @@ class DataMuxer(object):
         ----------
         bin_edges : list
             list of two-element items like [(t1, t2), (t3, t4), ...]
+        bin_anchors : list
+            These are time points where interpolated values will be evaluated.
+            Bin centers are usually a good choice.
         interpolation : dict
             Override the default interpolation (upsampling) behavior of any
             data source by passing a dictionary of source names mapped onto

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -326,15 +326,9 @@ class DataMuxer(object):
         df : pandas.DataFrame
         """
         if include_all_timestamps:
-            # Store current state; reinstate it at the end.
-            timestamps_as_data = self._timestamps_as_data
-            for source in df.sources:
-                self.include_timestamp_data(source)
+            raise NotImplementedError("TODO")
 
         result = self._dataframe
-
-        if include_all_timestamps:
-            self._timestamps_as_data = timestamps_as_data
 
         return result
 

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -181,6 +181,10 @@ class DataMuxer(object):
 
         self.plan = Planner(self)
 
+    @property
+    def columns(self):
+        return list(self.sources) + list(self._timestamps_as_data) + ['time']
+
     @classmethod
     def from_tuples(cls, event_tuples, sources=None):
         """
@@ -652,8 +656,7 @@ class Planner(object):
         if interpolation is None:
             interpolation = dict()
         if use_cols is None:
-            use_cols = (list(self.dm.sources) +
-                        list(self.dm._timestamps_as_data) + ['time'])
+            use_cols = self.dm.columns
         rules = dict(upsample={}, downsample={})
         for name in use_cols:
             col_info = self.dm.col_info[name]

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -308,6 +308,33 @@ class DataMuxer(object):
             self._stale = False
         return self._df
 
+    def to_sparse_dataframe(self, include_all_timestamps=False):
+        """Obtain all measurements in a DataFrame, one row per Event time.
+
+        Parameters
+        ----------
+        include_all_timestamps : bool
+            The result will always contain a 'time' column but, by default,
+            not timestamps for individual data sources like 'motor_timestamp'. 
+            Set this to True to export timestamp columns for each data column
+
+        Returns
+        -------
+        df : pandas.DataFrame
+        """
+        if include_all_timestamps:
+            # Store current state; reinstate it at the end.
+            timestamps_as_data = self._timestamps_as_data
+            for source in df.sources:
+                self.include_timestamp_data(source)
+
+        result = self._dataframe
+
+        if include_all_timestamps:
+            self._timestamps_as_data = timestamps_as_data
+
+        return result
+
     def include_timestamp_data(self, source_name):
         """Add the exact timing of a data source as a data column."""
         # self._timestamps_as_data is a set of sources who timestamps

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -293,7 +293,7 @@ class DataMuxer(object):
         # Rebuild the DataFrame if more data has been added.
         if self._stale:
             self._df = pd.DataFrame(list(self._data))
-            self._df['time'] = pd.to_datetime(list(self._time), unit='s')
+            self._df['time'] = list(self._time)
             if self._timestamps_as_data:
                 # Only build this if we need it.
                 # TODO: We shouldn't have to build
@@ -302,8 +302,7 @@ class DataMuxer(object):
                 timestamps = pd.DataFrame(list(self._timestamps))
             for source_name in self._timestamps_as_data:
                 col_name = _timestamp_col_name(source_name)
-                self._df[col_name] = pd.to_datetime(timestamps[source_name],
-                                                    unit='s')
+                self._df[col_name] = timestamps[source_name]
                 logger.debug("Including %s timestamps as data", source_name)
             self._stale = False
         return self._df

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -389,9 +389,7 @@ class DataMuxer(object):
         if include_all_timestamps:
             raise NotImplementedError("TODO")
 
-        result = self._dataframe
-
-        return result
+        return self._dataframe.copy()
 
     def include_timestamp_data(self, source_name):
         """Add the exact timing of a data source as a data column."""
@@ -701,6 +699,7 @@ def _build_verified_downsample(downsample, expected_shape):
 
 def _timestamp_col_name(source_name):
     return '{0}_timestamp'.format(source_name)
+
 
 def _normalize_string_none(val):
     "Replay passes 'None' to mean None."

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -381,7 +381,7 @@ class DataMuxer(object):
         http://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html
         """
         col = self._dataframe.sort()[source_name]
-        centers = col.dropna().index.values
+        centers = self._dataframe['time'].reindex_like(col.dropna())
 
         # [2, 4, 6] -> [-inf, 3, 5, inf]
         bin_edges = np.mean([centers[1:], centers[:-1]], 0)

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -651,24 +651,21 @@ class Planner(object):
         rules = dict(upsample={}, downsample={})
         for name in use_cols:
             col_info = self.dm.col_info[name]
-            try:
-                upsample = interpolation[name]
-            except (TypeError, KeyError):
-                upsample = col_info.upsample
+            if interpolation is None:
+                interpolation = dict()
             else:
-                upsample = _validate_upsample(upsample)
+                upsample = _validate_upsample(
+                    interpolation.get(name, col_info.upsample))
             upsample = _normalize_string_none(upsample)
             if not upsample is None and (col_info.ndim > 0):
                 raise NotImplementedError(
                     "Only scalar data can be upsampled. "
                     "The {0}-dimensional source {1} was given the upsampling "
                     "rule {2}.".format(col_info.ndim, name, upsample))
-            try:
-                downsample = agg[name]
-            except (TypeError, KeyError):
-                downsample = col_info.downsample
+            if agg is None:
+                agg = dict()
             else:
-                downsample = _validate_downsample(downsample)
+                downsample = _validate_downsample(agg.get(name, col_info.downsample))
             downsample = _normalize_string_none(downsample)
             rules['upsample'][name] = upsample
             rules['downsample'][name] = downsample

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -574,7 +574,7 @@ class DataMuxer(object):
             result[name]['min'] = min_series
 
         result = pd.concat(result, axis=1)  # one MultiIndexed DataFrame
-        result.index.name = 'bin number'
+        result.index.name = 'bin'
         return result
 
     def __getitem__(self, source_name):

--- a/dataportal/replay/muxer/model.py
+++ b/dataportal/replay/muxer/model.py
@@ -208,7 +208,7 @@ class MuxerModel(Atom):
         self.event_queue = EventQueue(self.header)
         self.get_new_data()
         # change the dataframe first
-        self.dataframe = self.data_muxer._dataframe
+        self.dataframe = self.data_muxer.to_sparse_dataframe()
         # then change the id
         # (The scalar_model depends on this order being dataframe then id)
         self.header_id = self.header.run_start_id
@@ -234,7 +234,7 @@ class MuxerModel(Atom):
             self.data_muxer = data_muxer
         else:
             self.data_muxer.append_events(events)
-            self.dataframe = self.data_muxer._dataframe
+            self.dataframe = self.data_muxer.to_sparse_dataframe()
             # update the column information
             self._verify_column_info()
             try:
@@ -298,7 +298,7 @@ class MuxerModel(Atom):
             # normalize the new dataframe
             self._normalize_all(dataframe)
         else:
-            dataframe = self.data_muxer._dataframe
+            dataframe = self.data_muxer.to_sparse_dataframe()
         # trigger the magic message passing cascade by assigning a new
         # dataframe to the instance data_frame attribute
         self.dataframe = dataframe

--- a/dataportal/replay/scalar/model.py
+++ b/dataportal/replay/scalar/model.py
@@ -235,7 +235,7 @@ class ScalarCollection(Atom):
     x_index = Int()
 
     # name of the column to align against
-    x_is_time = Bool(True)
+    x_is_index = Bool(True)
     # name of all columns that the data muxer knows about
     data_cols = List()
 
@@ -299,9 +299,9 @@ class ScalarCollection(Atom):
                 self.x_index = self.scalar_models.keys().index(self.x)
 
 
-    @observe('x', 'x_is_time', 'y')
+    @observe('x', 'x_is_index', 'y')
     def save_plotting_state(self, changed):
-        plotting_state = {'x': self.x, 'y': self.y, 'x_is_time': self.x_is_time}
+        plotting_state = {'x': self.x, 'y': self.y, 'x_is_index': self.x_is_index}
         logger.debug('writing plotting state for id: [%s] ... %s',
             self.dataframe_id, plotting_state)
         replay.core.save_state(self.history, self.dataframe_id, plotting_state)
@@ -325,7 +325,7 @@ class ScalarCollection(Atom):
                                self.scalar_models.items()
                                if col_model.is_plotting]
         old_x = self.x
-        old_x_is_time = self.x_is_time
+        old_x_is_index = self.x_is_index
 
         scalar_cols = [col for col in self.dataframe.columns
                      if self.dataframe[col].dropna().values[0].shape == tuple()]
@@ -343,10 +343,10 @@ class ScalarCollection(Atom):
             scalar_model.is_plotting = scalar_name in old_plotting_values
         if old_x in self.scalar_models.keys():
             self.x = old_x
-            self.x_is_time = old_x_is_time
+            self.x_is_index = old_x_is_index
         else:
             self.x = self.scalar_models.keys()[0]
-            self.x_is_time = True
+            self.x_is_index = True
         self.get_new_data_and_plot()
 
     def _do_magic(self, scalar_cols):
@@ -408,17 +408,17 @@ class ScalarCollection(Atom):
         self.get_new_data_and_plot()
 
     def get_new_data_and_plot(self):
-        """Helper function to shunt plotting with x as time or as a data column.
+        """Helper function to shunt plotting with the index or a column as x.
         """
         if self.dataframe is None:
             return
-        if self.x_is_time:
-            self.plot_by_time()
+        if self.x_is_index:
+            self.plot_by_index()
         else:
             self.plot_by_x()
 
-    def plot_by_time(self):
-        self._conf.xlabel = 'time'
+    def plot_by_index(self):
+        self._conf.xlabel = 'index (sequential counting numbers)'
         data_dict = {model_name: (model.index, model.data)
                      for model_name, model in self.column_models.items()}
         self._plot(data_dict)

--- a/dataportal/replay/scalar/view.enaml
+++ b/dataportal/replay/scalar/view.enaml
@@ -59,14 +59,14 @@ enamldef PlotControls(Container):
                 editable = True
                 index << scalar_collection.x_index
                 selected_item >> scalar_collection.x
-                enabled << not scalar_collection.x_is_time
+                enabled << not scalar_collection.x_is_index
             Label:
                 text = "X axis options"
             Form:
                 row_spacing = 0
                 CheckBox: btn_time:
-                    text = 'Plot againt time'
-                    checked := scalar_collection.x_is_time
+                    text = 'Plot againt index'
+                    checked := scalar_collection.x_is_index
                     clicked ::
                         scalar_collection.get_new_data_and_plot()
         GroupBox: persistence:

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -198,7 +198,7 @@ class TestImageAndScalar(unittest.TestCase):
         self.assertEqual(datapoint.ndim, 2)
 
         binned = self.dm.bin_on('img', agg={'Tsam': 'mean'})
-        binned_datapoint = binned['img']['val_raw'].values[2]
+        binned_datapoint = binned['img']['val'].values[2]
         self.assertEqual(binned_datapoint.ndim, 2)
 
         assert_array_equal(datapoint, binned_datapoint)

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -145,15 +145,8 @@ class CommonBinningTests(object):
 
         # If there is an interpolation rule, there should be no missing values
         # except (perhaps) at the edges outside the domain of the sparse col.
-        first = self.dm[self.sparse].first_valid_index()
-        last = self.dm[self.sparse].last_valid_index()
-        expected_len = 2 + len(self.dm[self.dense].loc[first:last])
-        # print('result1 columns: {}'.format(result1[self.sparse].columns))
-        # print('result2 columns: {}'.format(result2[self.sparse].columns))
-        res1 = result1[self.sparse][result1[self.sparse].columns[0]]
-        res2 = result2[self.sparse][result2[self.sparse].columns[0]]
-        self.assertLess(res1.count(), expected_len)
-        self.assertEqual(res2.count(), expected_len)
+        first, last = result1[self.sparse].dropna().index[[0, -1]]
+        self.assertTrue(result2.loc[first:last, self.sparse].notnull().all().all())
 
         # There should not be stats columns.
         self.assertFalse('max' in result1[self.dense].columns)

--- a/dataportal/tests/test_muxer.py
+++ b/dataportal/tests/test_muxer.py
@@ -114,6 +114,7 @@ class CommonBinningTests(object):
         bad_binning = lambda: self.dm.bin_on(self.sparse)
         self.assertRaises(BinningError, bad_binning)
 
+        self.dm.plan.bin_on(self.sparse, agg={self.dense: self.agg})
         result = self.dm.bin_on(self.sparse,
                                 agg={self.dense: self.agg})
         # With downsampling, the result should have as many entires as the
@@ -138,6 +139,7 @@ class CommonBinningTests(object):
         result1 = self.dm.bin_on(self.dense)
         actual_len1 = len(result1)
         self.assertEqual(actual_len1, expected_len)
+        self.dm.plan.bin_on(self.dense, interpolation={self.sparse: self.interp})
         result2 = self.dm.bin_on(self.dense,
                                  interpolation={self.sparse: self.interp})
         actual_len2 = len(result2)
@@ -190,6 +192,7 @@ class TestImageAndScalar(unittest.TestCase):
         self.assertTrue(self.dm._dataframe.index.is_unique)
 
     def test_bin_on_image(self):
+        self.dm.plan.bin_on('img', agg={'Tsam': 'mean'})
         binned = self.dm.bin_on('img', agg={'Tsam': 'mean'})
         self.assertEqual(len(binned), len(self.dm['img']))
 
@@ -197,6 +200,7 @@ class TestImageAndScalar(unittest.TestCase):
         datapoint = self.dm['img'].values[2]
         self.assertEqual(datapoint.ndim, 2)
 
+        self.dm.plan.bin_on('img', agg={'Tsam': 'mean'})
         binned = self.dm.bin_on('img', agg={'Tsam': 'mean'})
         binned_datapoint = binned['img']['val'].values[2]
         self.assertEqual(binned_datapoint.ndim, 2)

--- a/dataportal/tests/test_replay.py
+++ b/dataportal/tests/test_replay.py
@@ -160,8 +160,8 @@ def test_replay_plotx_ploty():
         assert len([scalar_model for scalar_model
                     in ui.scalar_collection.scalar_models.values()
                     if scalar_model.is_plotting]) == 1
-        # the x axis should not be time
-        assert not ui.scalar_collection.x_is_time
+        # the x axis should not be the index
+        assert not ui.scalar_collection.x_is_index
     except AssertionError:
         # gotta destroy the app or it will cause cascading errors
         ui.close()
@@ -200,8 +200,8 @@ def test_replay_plotx_2ploty():
         assert len([scalar_model for scalar_model
                     in ui.scalar_collection.scalar_models.values()
                     if scalar_model.is_plotting]) == len(ploty)
-        # the x axis should not be time
-        assert ui.scalar_collection.x_is_time
+        # the x axis should not be the index
+        assert ui.scalar_collection.x_is_index
     except AssertionError:
         # gotta destroy the app or it will cause cascading errors
         ui.close()
@@ -212,7 +212,7 @@ def test_replay_plotx_2ploty():
 
 
 # this function tests that a live-view replay will correctly plot
-# time on the x axis with none of the y values enabled for plotting if
+# the index on the x axis with none of the y values enabled for plotting if
 # 'ploty' and 'plotx' are not found in the run header
 @skip_if(six.PY3)
 def test_replay_plotting():
@@ -235,8 +235,8 @@ def test_replay_plotting():
         assert len([scalar_model for scalar_model
                     in ui.scalar_collection.scalar_models.values()
                     if scalar_model.is_plotting]) == 0
-        # the x axis should not be time
-        assert ui.scalar_collection.x_is_time
+        # the x axis should not be the index
+        assert ui.scalar_collection.x_is_index
     except AssertionError:
         # gotta destroy the app or it will cause cascading errors
         ui.close()
@@ -269,7 +269,7 @@ def test_replay_persistence():
     hdr_update_rate1 = random.randint(50000, 10000000)
     num_to_retrieve1 = random.randint(10, 20)
     # store some state
-    state1 = {'x': 'Tsam', 'y': ['Tsam', 'point_det'], 'x_is_time': True}
+    state1 = {'x': 'Tsam', 'y': ['Tsam', 'point_det'], 'x_is_index': True}
     h.put(six.text_type(rs1.id), state1)
     returned_state = h.get(six.text_type(rs1.id))
     h.put('WatchForHeadersModel', {'update_rate': hdr_update_rate1})
@@ -277,7 +277,7 @@ def test_replay_persistence():
     h.put('GetLastModel', {'num_to_retrieve': num_to_retrieve1})
     # store some more state
     h.put(six.text_type(rs2.id), {'y': ['Tsam', 'point_det'],
-                                  'x_is_time': True})
+                                  'x_is_index': True})
 
     # open up replay
     app = QtApplication()
@@ -298,7 +298,7 @@ def test_replay_persistence():
         # check that the scalar collection is correctly loading plotting state
         assert ui.scalar_collection.x == state1['x']
         # check that the scalar collection is correctly loading plotting state
-        assert ui.scalar_collection.x_is_time == state1['x_is_time']
+        assert ui.scalar_collection.x_is_index == state1['x_is_index']
         y_matches = True
         for y in ui.scalar_collection.y:
             if y not in state1['y']:
@@ -321,7 +321,7 @@ def test_replay_persistence():
         raise
 
     # store some state for the 2nd header that differs from the first
-    state2 = {'x': 'point_det', 'y': ['Tsam'], 'x_is_time': False}
+    state2 = {'x': 'point_det', 'y': ['Tsam'], 'x_is_index': False}
     h.put(six.text_type(rs2.id), state2)
     hdr2 = db.find_headers(_id=rs2.id)[0]
     ui.muxer_model.header = hdr2
@@ -338,7 +338,7 @@ def test_replay_persistence():
         # check that the scalar collection is correctly loading plotting state
         assert ui.scalar_collection.x == state2['x']
         # check that the scalar collection is correctly loading plotting state
-        assert ui.scalar_collection.x_is_time == state2['x_is_time']
+        assert ui.scalar_collection.x_is_index == state2['x_is_index']
         # check that the scalar collection is correctly loading plotting state
         for y in ui.scalar_collection.y:
             if y not in state2['y']:
@@ -380,7 +380,7 @@ def test_replay_persistence():
         # check that the scalar collection is correctly loading plotting state
         assert ui.scalar_collection.x == state2['x']
         # check that the scalar collection is correctly loading plotting state
-        assert ui.scalar_collection.x_is_time == state2['x_is_time']
+        assert ui.scalar_collection.x_is_index == state2['x_is_index']
         # check that the scalar collection is correctly loading plotting state
         for y in ui.scalar_collection.y:
             if y not in state2['y']:
@@ -423,7 +423,7 @@ def test_replay_persistence():
         # check that the scalar collection is correctly loading plotting state
         assert ui.scalar_collection.x == state1['x']
         # check that the scalar collection is correctly loading plotting state
-        assert ui.scalar_collection.x_is_time == state1['x_is_time']
+        assert ui.scalar_collection.x_is_index == state1['x_is_index']
         # check that the scalar collection is correctly loading plotting state
         for y in ui.scalar_collection.y:
             if y not in state1['y']:


### PR DESCRIPTION
Some long-planned updates to the muxer:
- Rather than trying to convey upsampling and downsampling operations in column names (e.g., 'val_linear_mean'), all columns will be called 'val'. Instead, for each `DataMuxer.bin_*` function, there is now a `DataMuxer.plan.bin_*` function taking the exact same arguments. It returns an explanation of what resampling will be done for that given muxer object and function arguments. Example:
  
  ```
  In [21]: dm.plan.bin_on('Tsam')
  Out[21]: 
           downsampling_needed upsampling_possible downsample upsample
  Tsam                    False               False       None     None
  point_det                True               False       None     None
  time                     True               False       mean   linear
  ```
- Binning operations return a DataFrame indexed by bin number, not time. A new `time` column contains the Event time.
- Provide `.to_sparse_dataframe()`, allowing us to remove or refactor `_dataframe` in the future.
- Remove the notion of bin anchoring, simplifying the bin functions considerably. Now that bins are indexed by number, there is no anchoring.
- Simplify API: `from dataportal import DataBroker, DataMuxer`
