### PR TITLE
Autolim

### DIFF
--- a/dataportal/replay/scalar/model.py
+++ b/dataportal/replay/scalar/model.py
@@ -74,8 +74,6 @@ class ScalarConfig(Atom):
         self.replot()
 
     def replot(self):
-        self._ax.relim(visible_only=True)
-        self._ax.autoscale_view(tight=True)
         if self._ax.figure.canvas is not None:
             self._ax.figure.canvas.draw()
 
@@ -252,6 +250,8 @@ class ScalarCollection(Atom):
     use_ram_state = Bool(False)
     # tell replay to use the state from the last time this header was viewed
     use_disk_state = Bool(True)
+
+    autolim_axes = Bool(True)
 
     def __init__(self, history, **kwargs):
         self.history = history
@@ -455,8 +455,9 @@ class ScalarCollection(Atom):
                 self._ax.legend(arts, labs).draggable()
             else:
                 self._ax.legend(legend_pairs)
-            self._ax.relim(visible_only=True)
-            self._ax.autoscale_view(tight=True)
+            if self.autolim_axes:
+                self._ax.relim(visible_only=True)
+                self._ax.autoscale_view(tight=True)
             self._ax.grid(self._conf.grid)
             self._ax.set_ylabel(self._conf.ylabel)
             self._ax.set_xlabel(self._conf.xlabel)

--- a/dataportal/replay/scalar/model.py
+++ b/dataportal/replay/scalar/model.py
@@ -400,10 +400,6 @@ class ScalarCollection(Atom):
     def update_col_names(self, changed):
         pass
 
-    @observe('xlim', 'ylim')
-    def _lims_changed(self, changed):
-        print(changed)
-
     @observe('autolim_axes')
     def _autolim_changed(self, changed):
         self.xlim = self._ax.get_xlim()

--- a/dataportal/replay/scalar/view.enaml
+++ b/dataportal/replay/scalar/view.enaml
@@ -103,19 +103,16 @@ enamldef PlotView(Container):
     Container:
         constraints = [
             vbox(
-                hbox(check, autolim, spacer),
+                hbox(autolim, spacer),
                 vbox(canvas),
             ),
         ]
-        CheckBox: check:
-            text = 'Toolbar Visible'
-            checked := canvas.toolbar_visible
         CheckBox: autolim:
             text = "Autoscale limits"
             checked := scalar_collection.autolim_axes
         MPLCanvas: canvas:
             figure << scalar_collection._fig
-            toolbar_visible = False
+            toolbar_visible = True
 
 
 enamldef ScalarContainer(Window): window:

--- a/dataportal/replay/scalar/view.enaml
+++ b/dataportal/replay/scalar/view.enaml
@@ -103,15 +103,16 @@ enamldef PlotView(Container):
     Container:
         constraints = [
             vbox(
-                hbox(check, spacer, fit),
+                hbox(check, autolim, spacer),
                 vbox(canvas),
             ),
         ]
         CheckBox: check:
             text = 'Toolbar Visible'
             checked := canvas.toolbar_visible
-        CheckBox: fit:
-            text = 'Fitting Visible'
+        CheckBox: autolim:
+            text = "Autoscale limits"
+            checked := scalar_collection.autolim_axes
         MPLCanvas: canvas:
             figure << scalar_collection._fig
             toolbar_visible = False


### PR DESCRIPTION
Adds a checkbox to the GUI labeled "Autoscale limits" that, when unchecked will not automatically update the limits on the visible plot.  The plot limits will persist to a different scan if the selected scan is changed.  The plot limits also persist when replay is opened in 'live' mode

Note: This PR has commits from #151 because I needed those commits to test the live mode
