### PR TITLE
Scan ID slicing

### DIFF
--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -41,7 +41,7 @@ class _DataBrokerClass(object):
                     # User passed something like [:] or [3:]. Seems dangerous.
                     raise ValueError("Range of scan IDs must include an "
                                      "explicit upper bound.")
-                keys = range(start, key.stop)
+                keys = range(start, key.stop, key.step)
                 return [cls.__getitem__(k) for k in keys]
             if ((key.start is None or key.start < 0) and
                 (key.stop is None or key.stop < 0)):

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -186,6 +186,25 @@ def test_scan_id_lookup():
     assert_equal(scan_id, 3)
     # This should be the most *recent* Scan 3. There is ambiguity.
     assert_equal(owner, 'nedbrainard')
+    # Slicing [i:j] gets the most recents scans with IDs in range(i, j).
+    headers = db[2:4]
+    scan_ids = [h.scan_id for h in headers]
+    assert_equal(scan_ids, [2, 3])
+    all_owners_are_ned = all([h.owner == 'nedbrainard' for h in headers])
+    assert_true(all_owners_are_ned)
+
+    # Check that bad slicing raises.
+    f = lambda: db[-3:1]  # mixing - and + is nonsensical
+    assert_raises(ValueError, f)
+    f = lambda: db[:-3]  # infinitely into the past is too greedy
+    assert_raises(ValueError, f)
+    f = lambda: db[1:]  # dangerously ambiguous
+    assert_raises(ValueError, f)
+    db[:3]  # but this is fine, and should not raise
+
+    # Also, passing something is not an int, slice, or string should raise.
+    f = lambda: db[2.5]
+    assert_raises(ValueError, f)
 
 def test_uid_lookup():
     uid = str(uuid.uuid4())


### PR DESCRIPTION
By popular demand, fetch multiple scan IDs with slicing syntax. `db[2:5]` gets the scan IDs in `range(2, 5)`, which is 2, 3, and 4.

This improves test coverage of the various ValueErrors that catch inputs that are illegal (`[-2:5]`) or unallowably dangerous (`[3:]`).

Implementation Details / Design Rationale:
- As usual, where the scan ID is ambiguous, the most recent one is used. This will probably lead to someone someday accidentally getting old scans, but this is the best we can do.
- One might expect pandas-like label-based slicing, where [2:3] return 2, 3, 4 -- not 2, 3 as in standard Python slicing. But (1) this is a sharp edge of pandas, perhaps best not imitated, and (2) users seems to view scan ID as an auto-incrementing counter, not a "label" per se.
