### PR TITLE
ENH: Add pims reader to broker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
   - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install -n testenv --yes atom; fi'
   - source activate testenv
   - 'pip install coveralls'
+  - 'pip install prettytable'
   - 'pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'
   - 'pip install https://github.com/NSLS-II/channelarchiver/zipball/master#egg=channelarchiver'

--- a/dataportal/__init__.py
+++ b/dataportal/__init__.py
@@ -2,7 +2,7 @@ import sys
 import logging
 from .sources import *
 
-__all__ = ['DataBroker', 'DataMuxer', 'StepScan', 'Images']
+__all__ = ['DataBroker', 'DataMuxer', 'StepScan', 'Images', 'SubtractedImages']
 logger = logging.getLogger(__name__)
 __version__ = 'v0.0.6.post0'
 

--- a/dataportal/__init__.py
+++ b/dataportal/__init__.py
@@ -2,7 +2,7 @@ import sys
 import logging
 from .sources import *
 
-__all__ = ['DataBroker', 'DataMuxer', 'StepScan']
+__all__ = ['DataBroker', 'DataMuxer', 'StepScan', 'Images']
 logger = logging.getLogger(__name__)
 __version__ = 'v0.0.6.post0'
 
@@ -15,6 +15,6 @@ else:
     del qt
 
 # generally useful imports
-from .broker import DataBroker
+from .broker import DataBroker, Images
 from .muxer import DataMuxer
 from .scans import StepScan

--- a/dataportal/__init__.py
+++ b/dataportal/__init__.py
@@ -15,6 +15,6 @@ else:
     del qt
 
 # generally useful imports
-from .broker import DataBroker, Images
+from .broker import DataBroker, Images, SubtractedImages
 from .muxer import DataMuxer
 from .scans import StepScan

--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,6 +1,7 @@
 from .simple_broker import (_DataBrokerClass, EventQueue, Header,
                             LocationError, IntegrityError)
 from .handler_registration import register_builtin_handlers
+from .pims_readers import Images
 
 DataBroker = _DataBrokerClass()  # singleton
 register_builtin_handlers()

--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,7 +1,7 @@
 from .simple_broker import (_DataBrokerClass, EventQueue, Header,
                             LocationError, IntegrityError)
 from .handler_registration import register_builtin_handlers
+DataBroker = _DataBrokerClass()  # singleton, used by pims_readers import below
 from .pims_readers import Images
 
-DataBroker = _DataBrokerClass()  # singleton
 register_builtin_handlers()

--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -2,6 +2,6 @@ from .simple_broker import (_DataBrokerClass, EventQueue, Header,
                             LocationError, IntegrityError)
 from .handler_registration import register_builtin_handlers
 DataBroker = _DataBrokerClass()  # singleton, used by pims_readers import below
-from .pims_readers import Images
+from .pims_readers import Images, SubtractedImages
 
 register_builtin_handlers()

--- a/dataportal/broker/pims_readers.py
+++ b/dataportal/broker/pims_readers.py
@@ -1,0 +1,43 @@
+from pims import FramesSequence
+from ..broker import DataBroker
+from filestore.api import retrieve
+
+class Images(FramesSequence):
+    def __init__(self, headers, name, process_func=None, dtype=None, as_grey=False):
+        """
+        Load images from a detector for given Header(s).
+
+        Parameters
+        ----------
+        headers : Header or list of Headers
+        name : str
+            alias (data key) of a detector
+        process_func: callable, optional
+            function to be applied to each image
+        dtype : numpy.dtype or str, optional
+            data type to cast each image as
+        as_grey : boolean, optional
+            False by default
+            quick-and-dirty way to ensure images are reduced to greyscale
+            To take more control over how conversion is performed,
+            use process_func above.
+
+        Example
+        -------
+        >>> header = DataBroker[-1]
+        >>> images = Images(header, 'my_detector_lightfield')
+        >>> for image in images:
+                # do something
+        """
+        self._dtype = dtype
+        events = DataBroker.fetch_events(headers, fill=False)
+        self._datum_uids = [event.data[name] for event in events]
+
+        self._validate_process_func(process_func)
+        self._as_grey(as_grey, process_func)
+
+    def get_frame(self, i):
+        img = retrieve(self._datum_uids[i])
+        if self._dtype is not None and img.dtype != self._dtype:
+            img = img.astype(self._dtype)
+        return Frame(self.process_func(img), frame_no=i)

--- a/dataportal/broker/pims_readers.py
+++ b/dataportal/broker/pims_readers.py
@@ -1,9 +1,15 @@
-from pims import FramesSequence
-from ..broker import DataBroker
+"""This module contains "PIMS readers" (see github.com/soft-matter/pims) that
+take in headers and detector aliases and return a sliceable generator of arrays."""
+
+from pims import FramesSequence, Frame
+from . import DataBroker
 from filestore.api import retrieve
+from skimage import img_as_float
+
 
 class Images(FramesSequence):
-    def __init__(self, headers, name, process_func=None, dtype=None, as_grey=False):
+    def __init__(self, headers, name, process_func=None, dtype=None,
+                 as_grey=False):
         """
         Load images from a detector for given Header(s).
 
@@ -30,14 +36,93 @@ class Images(FramesSequence):
                 # do something
         """
         self._dtype = dtype
-        events = DataBroker.fetch_events(headers, fill=False)
+        all_events = DataBroker.fetch_events(headers, fill=False)
+        # TODO Make this smarter by only grabbing events from the relevant
+        # descriptors. For now, we will do it this way to take advantage of
+        # header validation logical happening in fetch_events.
+        events = [event for event in all_events if name in event.data.keys()]
         self._datum_uids = [event.data[name] for event in events]
+        self._len = len(self._datum_uids)
+        example_frame = retrieve(self._datum_uids[0])
+        self._dtype = example_frame.dtype
+        self._shape = example_frame.shape
 
         self._validate_process_func(process_func)
         self._as_grey(as_grey, process_func)
+
+    @property
+    def pixel_type(self):
+        return self._dtype
+
+    @property
+    def frame_shape(self):
+        return self._shape
+
+    def __len__(self):
+        return self._len
 
     def get_frame(self, i):
         img = retrieve(self._datum_uids[i])
         if self._dtype is not None and img.dtype != self._dtype:
             img = img.astype(self._dtype)
         return Frame(self.process_func(img), frame_no=i)
+
+
+class SubtractedImages(FramesSequence):
+    def __init__(self, headers, lightfield_name, darkfield_name,
+                 process_func=None, dtype=None, as_grey=False):
+        """
+        Load images from a detector for given Header(s). Subtract
+        dark images from each corresponding light image automatically.
+
+        Parameters
+        ----------
+        headers : Header or list of Headers
+        lightfield_name : str
+            alias (data key) of lightfield images
+        darkfield_name : str
+            alias (data key) of darkfield images
+        process_func: callable, optional
+            function to be applied to each image
+        dtype : numpy.dtype or str, optional
+            data type to cast each image as
+        as_grey : boolean, optional
+            False by default
+            quick-and-dirty way to ensure images are reduced to greyscale
+            To take more control over how conversion is performed,
+            use process_func above.
+
+        Example
+        -------
+        >>> header = DataBroker[-1]
+        >>> images = SubtractedImages(header, 'my_lightfield', 'my_darkfield')
+        >>> for image in images:
+                # do something
+        """
+        self.light = Images(
+                headers, lightfield_name, process_func, dtype, as_grey)
+        self.dark = Images(
+                headers, darkfield_name, process_func, dtype, as_grey)
+        if len(self.light) != len(self.dark):
+            raise ValueError("The streams from {0} and {1} have unequal "
+                             "length and cannot be automatically subtracted.")
+        self._len = len(self.light)
+        example = img_as_float(self.light[0]) - img_as_float(self.dark[0])
+        self._dtype = example.dtype
+        self._shape = example.shape
+
+    def get_frame(self, i):
+        # Convert to float to avoid out-of-bounds wrap-around errors,
+        # as in 10-11 = 255.
+        return img_as_float(self.light[i]) - img_as_float(self.dark[i])
+
+    @property
+    def pixel_type(self):
+        return self._dtype
+
+    @property
+    def frame_shape(self):
+        return self._shape
+
+    def __len__(self):
+        return self._len

--- a/dataportal/broker/pims_readers.py
+++ b/dataportal/broker/pims_readers.py
@@ -49,7 +49,7 @@ class Images(FramesSequence):
 
     def get_frame(self, i):
         img = retrieve(self._datum_uids[i])
-        return Frame(self.process_func(img), frame_no=i)
+        return Frame(img, frame_no=i)
 
 
 class SubtractedImages(FramesSequence):

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -3,7 +3,6 @@ import sys
 import six  # noqa
 from six import StringIO
 from collections import defaultdict, Iterable, deque
-from .. import sources
 from ..utils.console import color_print
 from metadatastore.api import (Document, find_last, find_run_starts,
                                find_event_descriptors, find_run_stops,
@@ -190,30 +189,6 @@ class _DataBrokerClass(object):
         for rs in run_start:
             result.append(Header.from_run_start(rs))
         return result
-
-
-def _get_archiver_data(ca_host, channels, start_time, end_time):
-    archiver = sources.channelarchiver.Archiver(ca_host)
-    archiver_result = archiver.get(channels, start_time, end_time,
-                                   interpolation='raw')  # never interpolate
-    # Put archiver data into Documents, minimicking a MDS event stream.
-    events = list()
-    for ch_name, ch_data in zip(channels, archiver_result):
-        # Build a Event Descriptor.
-        descriptor = dict()
-        descriptor.time = start_time
-        descriptor['data_keys'] = {ch_name: dict(source=ch_name,
-                                   shape=[], dtype='number')}
-        descriptor = Document(descriptor)
-        for time, value in zip(ch_data.times, ch_data, values):
-            # Build an Event.
-            event = dict()
-            event['descriptor'] = descriptor
-            event['time'] = time
-            event['data'] = {ch_name: (value, time)}
-            event = Document(event)
-            events.append(event)
-    return events
 
 
 class EventQueue(object):

--- a/dataportal/examples/sample_data/image_and_scalar.py
+++ b/dataportal/examples/sample_data/image_and_scalar.py
@@ -12,6 +12,11 @@ import sys
 import metadatastore
 
 
+# number of motor positions to fake
+num1 = 20
+# number of temperatures to record per motor position
+num2 = 10
+
 # These are imported from MDS and cannot be imported as things.
 noisy = common.noisy
 example = common.example
@@ -68,11 +73,6 @@ def run(run_start=None, sleep=0):
     e_desc2 = insert_event_descriptor(
         run_start=run_start, data_keys=data_keys2, time=0.,
         uid=str(uuid.uuid4()))
-
-    # number of motor positions to fake
-    num1 = 20
-    # number of temperatures to record per motor position
-    num2 = 10
 
     events = []
     for idx1, i in enumerate(range(num1)):

--- a/dataportal/tests/test_misc.py
+++ b/dataportal/tests/test_misc.py
@@ -12,12 +12,24 @@ from numpy.testing.utils import assert_array_equal
 def test_watermark():
     watermark()
 
-def test_pims():
+def test_pims_images():
     header = db[-1]
     images = Images(header, 'img')
-    images[:5]
+    images[:5]  # smoke test
+    assert_equal(images.pixel_type, np.float64)
+    assert_array_equal(images.frame_shape, images[0].shape)
+    assert_equal(len(images), image_and_scalar.num1)
+
+def test_pims_subtracted_images():
+    header = db[-1]
+    images = Images(header, 'img')
     s_images = SubtractedImages(header, 'img', 'img')
-    assert_equal(len(images), len(s_images))
+    s_images[:5]  # smoke test
+    assert_equal(s_images.pixel_type, np.float64)
+    assert_array_equal(s_images.frame_shape, s_images[0].shape)
+    assert_equal(len(s_images), image_and_scalar.num1)
+
+    # We are subtracting an image from itself, so the result should be zero.
     expected = np.zeros(s_images.frame_shape)
     assert_array_equal(s_images[0], expected)
 

--- a/dataportal/tests/test_misc.py
+++ b/dataportal/tests/test_misc.py
@@ -1,4 +1,31 @@
 from ..utils.diagnostics import watermark
+from ..broker.pims_readers import Images, SubtractedImages
+from ..broker import DataBroker as db
+from ..examples.sample_data import image_and_scalar
+from metadatastore.utils.testing import mds_setup, mds_teardown
+from filestore.utils.testing import fs_setup, fs_teardown
+import numpy as np
+
+from nose.tools import assert_equal
+from numpy.testing.utils import assert_array_equal
 
 def test_watermark():
     watermark()
+
+def test_pims():
+    header = db[-1]
+    images = Images(header, 'img')
+    images[:5]
+    s_images = SubtractedImages(header, 'img', 'img')
+    assert_equal(len(images), len(s_images))
+    expected = np.zeros(s_images.frame_shape)
+    assert_array_equal(s_images[0], expected)
+
+def setup():
+    mds_setup()
+    fs_setup()
+    image_and_scalar.run()
+
+def teardown():
+    mds_teardown()
+    fs_teardown()


### PR DESCRIPTION
```
from dataportal import Images, DataBroker
header = DataBroker[-1]
images = Images(header, 'my_detector_lightfield')
for image in images:
    # do something
```

**Implementation details:** As with all pims readers, slicing on `images` returns a generator that only loads image data as it is needed. Random access is achieved by first loading all the events _without their data_ to create a "table of contents" of references to filestore. Then, when a frame is requested, filestore is invoked to load the actual data.
