### PR TITLE
MNT : do not use event.id

### DIFF
--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -259,9 +259,9 @@ class EventQueue(object):
 
         new_events = []
         for event in events:
-            if event.id not in self._known_ids:
+            if event.uid not in self._known_ids:
                 new_events.append(event)
-                self._known_ids.add(event.id)
+                self._known_ids.add(event.uid)
 
         # The major performance savings is here: only fill the new events.
         [fill_event(event) for event in new_events]

--- a/dataportal/examples/sample_data/frame_generators.py
+++ b/dataportal/examples/sample_data/frame_generators.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 import numpy as np
 from skxray import core
 
+
 def brownian(im_shape, step_scale=1, decay=30,
              I_fluc_function=None, step_fluc_function=None):
     """
@@ -55,8 +56,6 @@ def brownian(im_shape, step_scale=1, decay=30,
     if step_fluc_function is None:
         step_fluc_function = lambda step, count: None
 
-    scale_func = step_fluc_function
-
     if im_shape.ndim != 1 and len(im_shape) != 2:
         raise ValueError("image shape must be 2 dimensional "
                          "you passed in {}".format(im_shape))
@@ -70,8 +69,8 @@ def brownian(im_shape, step_scale=1, decay=30,
         # clip it
         cur_position = np.array([np.clip(v, 0, mx) for
                                  v, mx in zip(cur_position, im_shape)])
-        R = core.pixel_to_radius(im_shape,
-                                 cur_position).reshape(im_shape)
+        R = core.radial_grid(cur_position,
+                                 im_shape)
         I = I_func(count)
         im = np.exp((-R**2 / decay)) * I
         count += 1

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -360,9 +360,9 @@ class DataMuxer(object):
         is_new : bool
             True if event was added, False is it has already been added
         """
-        if event.id in self._known_events:
+        if event.uid in self._known_events:
             return False
-        self._known_events.add(event.id)
+        self._known_events.add(event.uid)
         self._stale = True
         if event.descriptor.id not in self._known_descriptors:
             self._process_new_descriptor(event.descriptor)
@@ -447,7 +447,7 @@ class DataMuxer(object):
         ----------
         include_all_timestamps : bool
             The result will always contain a 'time' column but, by default,
-            not timestamps for individual data sources like 'motor_timestamp'. 
+            not timestamps for individual data sources like 'motor_timestamp'.
             Set this to True to export timestamp columns for each data column
 
         Returns

--- a/replay/tests/test_replay.py
+++ b/replay/tests/test_replay.py
@@ -4,6 +4,7 @@ if six.PY2:
     import enaml
     from enaml.qt.qt_application import QtApplication
     from replay import replay
+    from replay.persist import History
 
 from functools import wraps
 from nose.tools import raises
@@ -20,7 +21,7 @@ import os
 import random
 import tempfile
 import uuid
-from replay.persist import History
+
 
 global hdr_temp_ramp, ev_temp_ramp
 global hdr_img_scalar, ev_img_scalar
@@ -400,4 +401,3 @@ def test_replay_persistence():
 
     ui.close()
     app.destroy()
-


### PR DESCRIPTION
`id` in the MongoDB ObjectID which should not be leaking out
of the metadatastore level.  Use `event.uid` (which is
the uid ophyd generates) instead.
