### PR TITLE
ENH: Add attrs to convert to datetime or timedelta w.r.t ref time.

### DIFF
--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -478,12 +478,9 @@ class DataMuxer(object):
     def _maybe_convert_times(self, data):
         if self.convert_times:
             if self.reference_time is None:
-                # times
                 return pd.to_datetime(data, unit='s')
-            else:
-                return pd.to_datetime(data, unit='s') - self.reference_time
-        else:
-            return data  # no-op
+            return pd.to_datetime(data, unit='s') - self.reference_time
+        return data  # no-op
 
     def include_timestamp_data(self, source_name):
         """Add the exact timing of a data source as a data column.

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -314,11 +314,26 @@ class DataMuxer(object):
         self._stale = True
 
         self.plan = self.Planner(self)
+        self.convert_times = True
+        self._reference_time = None
+
+    @property
+    def reference_time(self):
+        return self._reference_time
+
+    @reference_time.setter
+    def reference_time(self, val):
+        self._reference_time = pd.Timestamp(val, unit='s')
 
     @property
     def columns(self):
         "The columns of DataFrames returned by methods that return DataFrames."
-        return list(self.sources) + list(self._timestamps_as_data) + ['time']
+        return set(self.sources) | self._time_columns
+
+    @property
+    def _time_columns(self):
+        ts_names = [name + '_timestamp' for name in self._timestamps_as_data]
+        return {'time'} | set(ts_names)
 
     @classmethod
     def from_events(cls, events):
@@ -455,7 +470,30 @@ class DataMuxer(object):
         if include_all_timestamps:
             raise NotImplementedError("TODO")
 
-        return self._dataframe.copy()
+        result = self._dataframe.copy()
+        for col_name in self._time_columns:
+            result[col_name] = self._maybe_convert_times(result[col_name])
+        return result
+
+    def _maybe_convert_times(self, data):
+        if self.convert_times:
+            if self.reference_time is None:
+                # times
+                return pd.to_datetime(data, unit='s')
+            else:
+                return pd.to_datetime(data, unit='s') - self.reference_time
+        else:
+            return data  # no-op
+
+    def earliest_time(self):
+        """Return the time of the first Event in this Muxer.
+
+        Returns
+        -------
+        time : float
+            UNIX time (seconds since 1970)
+        """
+        return self._dataframe['time'].min()
 
     def include_timestamp_data(self, source_name):
         """Add the exact timing of a data source as a data column.
@@ -736,6 +774,21 @@ class DataMuxer(object):
 
         result = pd.concat(result, axis=1)  # one MultiIndexed DataFrame
         result.index.name = 'bin'
+
+        # Convert time timestamp or timedelta, depending on the state of
+        # self.convert_times and self.reference_time.
+        for col_name in self._time_columns:
+            if isinstance(result[col_name], pd.DataFrame):
+                subcols = result[col_name].columns
+                for subcol in subcols & {'max', 'min', 'val'}:
+                    result[(col_name, subcol)] = self._maybe_convert_times(
+                            result[(col_name, subcol)])
+                for subcol in subcols & {'std'}:
+                    result[(col_name, subcol)] = pd.to_timedelta(
+                            result[(col_name, subcol)], unit='s')
+            else:
+                result[col_name] = self._maybe_convert_times(
+                        result[col_name])
         return result
 
     def __getitem__(self, source_name):

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -485,16 +485,6 @@ class DataMuxer(object):
         else:
             return data  # no-op
 
-    def earliest_time(self):
-        """Return the time of the first Event in this Muxer.
-
-        Returns
-        -------
-        time : float
-            UNIX time (seconds since 1970)
-        """
-        return self._dataframe['time'].min()
-
     def include_timestamp_data(self, source_name):
         """Add the exact timing of a data source as a data column.
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -20,7 +20,7 @@ from dataportal.testing.noseclasses import KnownFailure
 
 plugins = [KnownFailure]
 env = {"NOSE_WITH_COVERAGE": 1,
-       'NOSE_COVER_PACKAGE': ['dataportal', 'replay'],
+       'NOSE_COVER_PACKAGE': ['dataportal'],
        'NOSE_COVER_HTML': 1}
 # Nose doesn't automatically instantiate all of the plugins in the
 # child processes, so we have to provide the multiprocess plugin with


### PR DESCRIPTION
1. By default, times will be shown in datetime format, backed by numpy datetimes.
2. If the `reference_time` attribute is set, times will be shown as float seconds since that reference time.
3. To keep times as floats since 1970 -- the current behavior -- set the `convert_times` attribute False.

For convenience, an `earliest_time` method has been added, so a nice workflow might be:

```
dm = DataMuxer.from_events(events)
dm.reference_time = dm.earliest_time()
```

That's about as "magical" as I want to get in the muxer API. Higher-level convenience functions like `step_scan` might take care of all this automatically.
