### PR TITLE
New doc format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
   - 'pip install coveralls'
   - 'pip install prettytable'
   - 'pip install humanize'
+  - 'pip install boltons'
   - 'pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'
   - 'pip install https://github.com/NSLS-II/channelarchiver/zipball/master#egg=channelarchiver'

--- a/dataportal/examples/hdf_io.py
+++ b/dataportal/examples/hdf_io.py
@@ -158,13 +158,15 @@ def hdf_data_io():
         spectrum_uid = get_data(v_pos, h_pos)
 
         # Put in actual ndarray data, as broker would do.
-        data1 = {'xrf_spectrum': (spectrum_uid, noisy(i)),
-                 'v_pos': (v_pos, noisy(i)),
-                 'h_pos': (h_pos, noisy(i))}
+        data1 = {'xrf_spectrum': spectrum_uid,
+                 'v_pos': v_pos,
+                 'h_pos': h_pos}
+        timestamps1 = {k: noisy(i) for k in data1}
 
         event_uid = insert_event(descriptor=descriptor_uid, seq_num=i,
                                  time=noisy(i), data=data1,
-                                 uid=str(uuid.uuid4()))
+                                 uid=str(uuid.uuid4()),
+                                 timestamps=timestamps1)
         event, = find_events(uid=event_uid)
         # test on retrieve data for all data sets
         events.append(event)

--- a/dataportal/examples/sample_data/image_and_scalar.py
+++ b/dataportal/examples/sample_data/image_and_scalar.py
@@ -88,26 +88,30 @@ def run(run_start_uid=None, sleep=0):
         fsid_y = save_ndarray(img_sum_y)
 
         # Put in actual ndarray data, as broker would do.
-        data1 = {'linear_motor': (i, noisy(i)),
-                 'total_img_sum': (img_sum, noisy(i)),
-                 'img': (fsid_img, noisy(i)),
-                 'img_sum_x': (fsid_x, noisy(i)),
-                 'img_sum_y': (fsid_y, noisy(i)),
-                 'img_x_max': (img_x_max, noisy(i)),
-                 'img_y_max': (img_y_max, noisy(i))
+        data1 = {'linear_motor': i,
+                 'total_img_sum': img_sum,
+                 'img': fsid_img,
+                 'img_sum_x': fsid_x,
+                 'img_sum_y': fsid_y,
+                 'img_x_max': img_x_max,
+                 'img_y_max': img_y_max
                  }
+        timestamps1 = {k: noisy(i) for k in data1}
 
         event_uid = insert_event(descriptor=descriptor1_uid, seq_num=idx1,
                                  time=noisy(i), data=data1,
+                                 timestamps=timestamps1,
                                  uid=str(uuid.uuid4()))
         event, = find_events(uid=event_uid)
         events.append(event)
         for idx2, i2 in enumerate(range(num2)):
             time = noisy(i/num2)
-            data2 = {'Tsam': (idx1 + np.random.randn()/100, time)}
+            data2 = {'Tsam': idx1 + np.random.randn()}
+            timestamps2 = {'Tsam': time}
             event_uid = insert_event(descriptor=descriptor2_uid,
                                      seq_num=idx2+idx1, time=time, data=data2,
-                                     uid=str(uuid.uuid4()))
+                                     uid=str(uuid.uuid4()),
+                                     timestamps=timestamps2)
             event, = find_events(uid=event_uid)
             events.append(event)
         ttime.sleep(sleep)

--- a/dataportal/examples/sample_data/step_scan.py
+++ b/dataportal/examples/sample_data/step_scan.py
@@ -29,9 +29,10 @@ def run(run_start=None, sleep=0):
     for i, (time, temp) in enumerate(zip(*deadbanded_ramp)):
         time = float(time)
         point_det = np.random.randn()
-        data = {'Tsam': (temp, time), 'point_det': (point_det, time)}
+        data = {'Tsam': temp, 'point_det': point_det}
+        timestamps = {'Tsam': time, 'point_det': time}
         event_uid = insert_event(descriptor=ev_desc, time=time, data=data,
-                                 seq_num=i)
+                                 seq_num=i, timestamps=timestamps)
         event, = find_events(uid=event_uid)
         events.append(event)
 


### PR DESCRIPTION
Cousin to NSLS-II/metadatastore#152

Data is stored in MDS like:

```
{'data': {key: (<value>, <timestamp>)}}
```

but now all public Event Documents in ophyd, MDS, and broker will use parallel dicts for more convenient lookup:

```
{'data': {key: <value>}}
{'timestamps': {key: <timestamp>}}
```
