### PR TITLE
WIP: overhaul API

### DIFF
--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,7 +1,5 @@
-from .simple_broker import (_DataBrokerClass, EventQueue, Header,
-                            LocationError, IntegrityError, fill_event)
+from .simple_broker import (DataBroker, Header, IntegrityError, fill_event)
 from .handler_registration import register_builtin_handlers
-DataBroker = _DataBrokerClass()  # singleton, used by pims_readers import below
 from .pims_readers import Images, SubtractedImages
 
 register_builtin_handlers()

--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,4 +1,4 @@
-from .simple_broker import (DataBroker, Header, IntegrityError, fill_event)
+from .simple_broker import (DataBroker, Header, get_events, get_table)
 from .handler_registration import register_builtin_handlers
 from .pims_readers import Images, SubtractedImages
 

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -5,7 +5,7 @@ from collections import Iterable, deque
 import pandas as pd
 from metadatastore.commands import (find_last, find_run_starts,
                                     find_descriptors,
-                                    fetch_events_generator, fetch_events_table)
+                                    get_events_generator, get_events_table)
 import metadatastore.doc as doc
 import metadatastore.commands as mc
 import filestore.api as fs
@@ -279,7 +279,7 @@ def get_events(headers, fields=None, fill=True):
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
-            for event in fetch_events_generator(descriptor):
+            for event in get_events_generator(descriptor):
                 for field in discard_fields:
                     del event.data[field]
                     del event.timestamps[field]
@@ -332,7 +332,7 @@ def get_table(headers, fields=None, fill=True):
                 discard_fields = []
             is_external = _inspect_descriptor(descriptor)
 
-            payload = fetch_events_table(descriptor)
+            payload = get_events_table(descriptor)
             descriptor, data, seq_nums, times, uids, timestamps = payload
             df = pd.DataFrame(index=seq_nums)
             df['time'] = times

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -270,11 +270,13 @@ def get_events(headers, fields=None, fill=True):
     for header in headers:
         descriptors = find_descriptors(header['start']['uid'])
         for descriptor in descriptors:
+            all_fields = set(descriptor['data_keys'])
             if fields:
-                all_fields = set(descriptor['data_keys'])
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
+            if discard_fields == all_fields:
+                continue
             for event in get_events_generator(descriptor):
                 for field in discard_fields:
                     del event.data[field]
@@ -282,7 +284,6 @@ def get_events(headers, fields=None, fill=True):
                 if fill:
                     fill_event(event)
                 yield event
-
 
 
 def get_table(headers, fields=None, fill=True):
@@ -321,11 +322,13 @@ def get_table(headers, fields=None, fill=True):
     for header in headers:
         descriptors = find_descriptors(header['start']['uid'])
         for descriptor in descriptors:
+            all_fields = set(descriptor['data_keys'])
             if fields:
-                all_fields = set(descriptor['data_keys'])
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
+            if discard_fields == all_fields:
+                continue
             is_external = _inspect_descriptor(descriptor)
 
             payload = get_events_table(descriptor)

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -330,8 +330,7 @@ def get_table(headers, fields=None, fill=True):
             payload = fetch_events_table(descriptor)
             descriptor, data, seq_nums, times, uids, timestamps = payload
             df = pd.DataFrame(index=seq_nums)
-            datetimes = [datetime.fromtimestamp(time) for time in times]
-            df['time'] = datetimes
+            df['time'] = times
             for field, values in six.iteritems(data):
                 # print('field = %s' % field)
                 if field in discard_fields:

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -26,7 +26,7 @@ class _DataBrokerClass(object):
             if key.start is not None and key.start > -1:
                 raise ValueError("Slices must be negative. The most recent "
                                  "run is referred to as -1.")
-            if key.stop is not None and key.stop > -1:
+            if key.stop is not None and key.stop > 0:
                 raise ValueError("Slices must be negative. The most recent "
                                  "run is referred to as -1.")
             if key.stop is not None:

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -232,7 +232,7 @@ class IntegrityError(Exception):
     pass
 
 
-def get_events(headers, fields=None):
+def get_events(headers, fields=None, fill=True):
     """
     Get Events from given run(s).
 
@@ -242,6 +242,8 @@ def get_events(headers, fields=None):
         The headers to fetch the events for
     fields : list, optional
         whitelist of field names of interest; if None, all are returned
+    fill : bool, optional
+        Whether externally-stored data should be filled in. Defaults to True
 
     Yields
     ------
@@ -275,7 +277,8 @@ def get_events(headers, fields=None):
                 for field in discard_fields:
                     del event.data[field]
                     del event.timestamps[field]
-                fill_event(event)
+                if fill:
+                    fill_event(event)
                 yield event
 
 
@@ -288,10 +291,10 @@ def get_table(headers, fields=None, fill=True):
     ----------
     headers : Header or iterable of Headers
         The headers to fetch the events for
-    fill : bool, optional
-        If non-scalar data should be filled in, Defaults to True
     fields : list, optional
         whitelist of field names of interest; if None, all are returned
+    fill : bool, optional
+        Whether externally-stored data should be filled in. Defaults to True
 
     Returns
     -------

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -10,8 +10,6 @@ import metadatastore.doc as doc
 import metadatastore.commands as mc
 import filestore.api as fs
 import logging
-from datetime import datetime
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -318,13 +316,11 @@ def get_table(headers, fields=None, fill=True):
         descriptors = find_descriptors(header['start']['uid'])
         dfs = []
         for descriptor in descriptors:
-#             print('descriptor = %s' % descriptor)
             if fields:
                 all_fields = set(descriptor['data_keys'].keys())
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
-#             print('discard_fields = %s' % discard_fields)
             is_external = _inspect_descriptor(descriptor)
 
             payload = fetch_events_table(descriptor)
@@ -332,12 +328,11 @@ def get_table(headers, fields=None, fill=True):
             df = pd.DataFrame(index=seq_nums)
             df['time'] = times
             for field, values in six.iteritems(data):
-                # print('field = %s' % field)
                 if field in discard_fields:
-                    print('Discarding field %s' % field)
+                    logger.debug('Discarding field %s', field)
                     continue
                 if is_external[field] and fill:
-                    print('filling data for %s' % field)
+                    logger.debug('filling data for %s', field)
                     # TODO someday we will have bulk retrieve in FS
                     values = [fs.retrieve(value) for value in values]
                 df[field] = values

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -19,7 +19,7 @@ class _DataBrokerClass(object):
     # You probably do not want to instantiate this; use
     # broker.DataBroker instead.
 
-    def __getitem__(cls, key):
+    def __getitem__(self, key):
         if isinstance(key, slice):
             # Interpret key as a slice into previous scans.
             if key.start is not None and key.start > -1:
@@ -75,7 +75,7 @@ class _DataBrokerClass(object):
         elif isinstance(key, Iterable):
             # Interpret key as a list of several keys. If it is a string
             # we will never get this far.
-            return [cls.__getitem__(k) for k in key]
+            return [self.__getitem__(k) for k in key]
         else:
             raise ValueError("Must give an integer scan ID like [6], a slice "
                              "into past scans like [-5], [-5:], or [-5:-9:2], "
@@ -83,7 +83,7 @@ class _DataBrokerClass(object):
                              "like ['a23jslk'].")
         return header
 
-    def __call__(cls, **kwargs):
+    def __call__(self, **kwargs):
         """Given search criteria, find Headers describing runs.
 
         This function returns a list of dictionary-like objects encapsulating
@@ -158,11 +158,17 @@ class _DataBrokerClass(object):
             result.append(Header.from_run_start(rs))
         return result
 
-    def find_headers(cls, **kwargs):
+    def find_headers(self, **kwargs):
         "This function is deprecated. Use DataBroker() instead."
-        warnings.warn(UserWarning, "Use DataBroker() instead of "
-                                   "DataBroker.find_headers()")
-        return cls(**kwargs)
+        warnings.warn("Use DataBroker() instead of "
+                      "DataBroker.find_headers()", UserWarning)
+        return self(**kwargs)
+
+    def fetch_events(self, headers, fill=True):
+        "This function is deprecated. Use top-level function get_events."
+        warnings.warn("Use top-level function "
+                                   "get_events() instead.", UserWarning)
+        return get_events(headers, None, fill)
 
 
 DataBroker = _DataBrokerClass()  # singleton, used by pims_readers import below
@@ -225,7 +231,7 @@ class Header(doc.Document):
             ev_descs = []
 
         d = {'start': run_start, 'stop': run_stop, 'descriptors': ev_descs}
-        return cls('header', d)
+        return self('header', d)
 
 
 class IntegrityError(Exception):

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -281,7 +281,7 @@ def get_events(headers, fields=None):
 
 
 
-def get_table(headers, fields=None):
+def get_table(headers, fields=None, fill=True):
     """
     Make a table (pandas.DataFrame) from given run(s).
 
@@ -331,7 +331,7 @@ def get_table(headers, fields=None):
             for field, values in six.iteritems(data):
                 if field in discard_fields:
                     continue
-                if is_external[field]:
+                if is_external[field] and fill:
                     # TODO someday we will have bulk retrieve in FS
                     data[field] = [fs.retrieve(value) for value in values]
                 df[field] = values

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -338,8 +338,9 @@ def get_table(headers, fields=None, fill=True):
                     print('Discarding field %s' % field)
                     continue
                 if is_external[field] and fill:
+                    print('filling data for %s' % field)
                     # TODO someday we will have bulk retrieve in FS
-                    data[field] = [fs.retrieve(value) for value in values]
+                    values = [fs.retrieve(value) for value in values]
                 df[field] = values
             dfs.append(df)
     return pd.concat(dfs)

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -268,8 +268,8 @@ def get_events(headers, fields=None, fill=True):
     for header in headers:
         descriptors = find_descriptors(header['start']['uid'])
         for descriptor in descriptors:
-            if fields is not None:
-                all_fields = set(descriptor['data_keys'].keys())
+            if fields:
+                all_fields = set(descriptor['data_keys'])
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
@@ -320,7 +320,7 @@ def get_table(headers, fields=None, fill=True):
         dfs = []
         for descriptor in descriptors:
             if fields:
-                all_fields = set(descriptor['data_keys'].keys())
+                all_fields = set(descriptor['data_keys'])
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -10,7 +10,8 @@ import metadatastore.doc as doc
 import metadatastore.commands as mc
 import filestore.api as fs
 import logging
-
+from datetime import datetime
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -317,19 +318,24 @@ def get_table(headers, fields=None, fill=True):
         descriptors = find_descriptors(header['start']['uid'])
         dfs = []
         for descriptor in descriptors:
-            if fields is not None:
+#             print('descriptor = %s' % descriptor)
+            if fields:
                 all_fields = set(descriptor['data_keys'].keys())
                 discard_fields = all_fields - fields
             else:
                 discard_fields = []
+#             print('discard_fields = %s' % discard_fields)
             is_external = _inspect_descriptor(descriptor)
 
             payload = fetch_events_table(descriptor)
             descriptor, data, seq_nums, times, uids, timestamps = payload
-            df = pd.DataFrame(times)
-            df.index = seq_nums
+            df = pd.DataFrame(index=seq_nums)
+            datetimes = [datetime.fromtimestamp(time) for time in times]
+            df['time'] = datetimes
             for field, values in six.iteritems(data):
+                # print('field = %s' % field)
                 if field in discard_fields:
+                    print('Discarding field %s' % field)
                     continue
                 if is_external[field] and fill:
                     # TODO someday we will have bulk retrieve in FS

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -234,10 +234,6 @@ class Header(doc.Document):
         return cls('header', d)
 
 
-class IntegrityError(Exception):
-    pass
-
-
 def get_events(headers, fields=None, fill=True):
     """
     Get Events from given run(s).
@@ -321,9 +317,9 @@ def get_table(headers, fields=None, fill=True):
         fields = []
     fields = set(fields)
 
+    dfs = []
     for header in headers:
         descriptors = find_descriptors(header['start']['uid'])
-        dfs = []
         for descriptor in descriptors:
             if fields:
                 all_fields = set(descriptor['data_keys'])
@@ -346,4 +342,8 @@ def get_table(headers, fields=None, fill=True):
                     values = [fs.retrieve(value) for value in values]
                 df[field] = values
             dfs.append(df)
-    return pd.concat(dfs)
+    if dfs:
+        return pd.concat(dfs)
+    else:
+        # edge case: no data
+        return pd.DataFrame()

--- a/dataportal/broker/simple_broker.py
+++ b/dataportal/broker/simple_broker.py
@@ -231,7 +231,7 @@ class Header(doc.Document):
             ev_descs = []
 
         d = {'start': run_start, 'stop': run_stop, 'descriptors': ev_descs}
-        return self('header', d)
+        return cls('header', d)
 
 
 class IntegrityError(Exception):

--- a/dataportal/examples/sample_data/frame_generators.py
+++ b/dataportal/examples/sample_data/frame_generators.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 import numpy as np
-from skxray.core import utils
 
 
 def brownian(im_shape, step_scale=1, decay=30,
@@ -69,8 +68,9 @@ def brownian(im_shape, step_scale=1, decay=30,
         # clip it
         cur_position = np.array([np.clip(v, 0, mx) for
                                  v, mx in zip(cur_position, im_shape)])
-        R = utils.radial_grid(cur_position,
-                                 im_shape)
+        X, Y = np.meshgrid(np.arange(im_shape[1]) - cur_position[1],
+                           np.arange(im_shape[0]) - cur_position[0])
+        R = np.sqrt(X**2 + Y**2)
         I = I_func(count)
         im = np.exp((-R**2 / decay)) * I
         count += 1

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from ..sources import channelarchiver as ca
 from ..sources import switch
-from ..broker import DataBroker as db
+from ..broker import DataBroker as db, get_events, get_table
 from ..examples.sample_data import temperature_ramp, image_and_scalar
 from nose.tools import (assert_equal, assert_raises, assert_true,
                         assert_false)
@@ -71,6 +71,9 @@ def test_basic_usage():
     get_events(header_1)
     get_events(header_ned)
     get_events(header_null)
+    get_table(header_1)
+    get_table(header_ned)
+    get_table(header_null)
 
 
 def test_indexing():

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -5,26 +5,17 @@ import six
 import uuid
 import logging
 import time as ttime
-import logging
-from collections import Iterable
-from datetime import datetime
 import numpy as np
 import pandas as pd
-from .. import sources
 from ..sources import channelarchiver as ca
 from ..sources import switch
-from ..broker import EventQueue, DataBroker as db
+from ..broker import DataBroker as db
 from ..examples.sample_data import temperature_ramp, image_and_scalar
-import dataportal
-from nose.tools import make_decorator
 from nose.tools import (assert_equal, assert_raises, assert_true,
-                        assert_false, raises)
+                        assert_false)
 
 
-from metadatastore.odm_templates import (EventDescriptor,
-                                         Event, RunStart, RunStop)
-from metadatastore.api import (insert_run_start,
-                               insert_run_stop, insert_descriptor,
+from metadatastore.api import (insert_run_start, insert_descriptor,
                                find_run_starts)
 from metadatastore.utils.testing import mds_setup, mds_teardown
 from filestore.utils.testing import fs_setup, fs_teardown
@@ -69,53 +60,13 @@ def test_basic_usage():
                          owner='nedbrainard', beamline_id='example',
                          uid=str(uuid.uuid4()))
     header_1 = db[-1]
-    # Exercise reprs.
-    header_1._repr_html_()
-    repr(header_1)
-    str(header_1)
-    headers = db[-3:]
-    headers._repr_html_()
-    repr(headers)
-    str(headers)
 
-    header_ned = db.find_headers(owner='nedbrainard')
-    header_null = db.find_headers(owner='this owner does not exist')
+    header_ned = db(owner='nedbrainard')
+    header_null = db(owner='this owner does not exist')
     # smoke test
     db.fetch_events(header_1)
     db.fetch_events(header_ned)
     db.fetch_events(header_null)
-
-
-def test_event_queue():
-    scan_id = np.random.randint(1e12)  # unique enough for government work
-    rs = insert_run_start(time=0., scan_id=scan_id,
-                          owner='queue-tester', beamline_id='example',
-                          uid=str(uuid.uuid4()))
-    header = db.find_headers(scan_id=scan_id)
-    queue = EventQueue(header)
-    # Queue should be empty until we create Events.
-    empty_bundle = queue.get()
-    assert_equal(len(empty_bundle), 0)
-    queue.update()
-    empty_bundle = queue.get()
-    assert_equal(len(empty_bundle), 0)
-    events = temperature_ramp.run(rs, make_run_stop=False)
-    # This should add a bundle of Events to the queue.
-    queue.update()
-    first_bundle = queue.get()
-    assert_equal(len(first_bundle), len(events))
-    more_events = temperature_ramp.run(rs, make_run_stop=False)
-    # Queue should be empty until we update.
-    empty_bundle = queue.get()
-    assert_equal(len(empty_bundle), 0)
-    queue.update()
-    second_bundle = queue.get()
-    assert_equal(len(second_bundle), len(more_events))
-    # Add Events from a different example into the same Header.
-    other_events = image_and_scalar.run(rs)
-    queue.update()
-    third_bundle = queue.get()
-    assert_equal(len(third_bundle), len(other_events))
 
 
 def test_indexing():
@@ -127,13 +78,13 @@ def test_indexing():
     header = db[-1]
     is_list = isinstance(header, list)
     assert_false(is_list)
-    scan_id = header.scan_id
+    scan_id = header['start']['scan_id']
     assert_equal(scan_id, 5)
 
     header = db[-2]
     is_list = isinstance(header, list)
     assert_false(is_list)
-    scan_id = header.scan_id
+    scan_id = header['start']['scan_id']
     assert_equal(scan_id, 4)
 
     f = lambda: db[-100000]
@@ -155,7 +106,7 @@ def test_indexing():
     num = len(headers)
     assert_equal(num, 1)
     header, = headers
-    scan_id = header.scan_id
+    scan_id = header['start']['scan_id']
     assert_equal(scan_id, 5)
 
     headers = db[-2:-1]
@@ -164,21 +115,21 @@ def test_indexing():
     print(headers)
     assert_equal(num, 1)
     header, = headers
-    scan_id = header.scan_id
+    scan_id = header['start']['scan_id']
     assert_equal(scan_id, 4)
 
     headers = db[-3:-1]
-    scan_ids = [h.scan_id for h in headers]
+    scan_ids = [h['start']['scan_id'] for h in headers]
     assert_equal(scan_ids, [4, 3])
 
     # fancy indexing, by location
     headers = db[[-3, -1, -2]]
-    scan_ids = [h.scan_id for h in headers]
+    scan_ids = [h['start']['scan_id'] for h in headers]
     assert_equal(scan_ids, [3, 5, 4])
 
     # fancy indexing, by scan id
     headers = db[[3, 1, 2]]
-    scan_ids = [h.scan_id for h in headers]
+    scan_ids = [h['start']['scan_id'] for h in headers]
     assert_equal(scan_ids, [3, 1, 2])
 
 
@@ -193,10 +144,10 @@ def test_scan_id_lookup():
     print(rd1)
     print(rd2)
     header = db[3 + 314159]
-    scan_id = header['scan_id']
-    owner = header['run_start']['owner']
+    scan_id = header['start']['scan_id']
+    owner = header['start']['owner']
     assert_equal(scan_id, 3 + 314159)
-    assert_equal(rd2[2], header['uid'])
+    assert_equal(rd2[2], header['start']['uid'])
     # This should be the most *recent* Scan 3 + 314159. There is ambiguity.
     assert_equal(owner, 'nedbrainard')
 
@@ -209,12 +160,12 @@ def test_uid_lookup():
     insert_run_start(time=100., scan_id=1, uid=uid2,
                      owner='drstrangelove', beamline_id='example')
     # using full uid
-    actual_uid = db[uid]["uid"]
+    actual_uid = db[uid]['start']['uid']
     assert_equal(actual_uid, uid)
     assert_equal(rs1, uid)
 
     # using first 6 chars
-    actual_uid = db[uid[:6]]["uid"]
+    actual_uid = db[uid[:6]]['start']['uid']
     assert_equal(actual_uid, uid)
     assert_equal(rs1, uid)
 
@@ -238,8 +189,8 @@ def test_data_key():
                             uid=str(uuid.uuid4()))
     insert_descriptor(run_start=rs2_uid, data_keys=data_keys, time=200.,
                             uid=str(uuid.uuid4()))
-    result1 = db.find_headers(data_key='fork')
-    result2 = db.find_headers(data_key='fork', start_time=150)
+    result1 = db(data_key='fork')
+    result2 = db(data_key='fork', start_time=150)
     assert_equal(len(result1), 2)
     assert_equal(len(result2), 1)
     actual = result2[0]["uid"]

--- a/dataportal/tests/test_broker.py
+++ b/dataportal/tests/test_broker.py
@@ -62,11 +62,15 @@ def test_basic_usage():
     header_1 = db[-1]
 
     header_ned = db(owner='nedbrainard')
+    header_ned = db.find_headers(owner='nedbrainard')  # deprecated API
     header_null = db(owner='this owner does not exist')
     # smoke test
     db.fetch_events(header_1)
     db.fetch_events(header_ned)
     db.fetch_events(header_null)
+    get_events(header_1)
+    get_events(header_ned)
+    get_events(header_null)
 
 
 def test_indexing():
@@ -112,7 +116,6 @@ def test_indexing():
     headers = db[-2:-1]
     assert_true(is_list)
     num = len(headers)
-    print(headers)
     assert_equal(num, 1)
     header, = headers
     scan_id = header['start']['scan_id']
@@ -141,8 +144,6 @@ def test_scan_id_lookup():
     rd2 = [insert_run_start(time=float(i)+1, scan_id=i + 1 + 314159,
                             owner='nedbrainard', beamline_id='example',
                             uid=str(uuid.uuid4())) for i in range(5)]
-    print(rd1)
-    print(rd2)
     header = db[3 + 314159]
     scan_id = header['start']['scan_id']
     owner = header['start']['owner']
@@ -193,7 +194,7 @@ def test_data_key():
     result2 = db(data_key='fork', start_time=150)
     assert_equal(len(result1), 2)
     assert_equal(len(result2), 1)
-    actual = result2[0]["uid"]
+    actual = result2[0]['start']['uid']
     assert_equal(actual, str(rs2.uid))
 
 


### PR DESCRIPTION
The new API returns simpler Headers, arranged along the lines of what we originally agreed on ("Headers are the RunStart, Event Descriptor, and Run Stop"), leaving user-friendly representations and custom rearrangements to be implemented at a higher level. One such implementation is [album](https://github.com/NSLS-II/album).

The full API is now simpler:
- `DataBroker[]` for slicing by scan ID(s) or recency
-  `DataBroker()` for building queries from keyword arguments
- `get_events`  return events generator
- `get_table`  return DataFrame
- `Header`, vastly simplified: it is merely `Document` with a dedicated constructor that accepts a Run Start Document

Everything is else gone. The nice pretty-printing logic will live on elsewhere. The old `DataBroker.find_headers` and `StepScan` are still there for now, but they issue warnings.
