### PR TITLE
API/CLN: Add get_images; refactor Images; remove SubtractedImages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda --yes
-  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas scikit-image h5py matplotlib coverage jsonschema jinja2
+  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas h5py coverage jsonschema jinja2
   # Dependencies not in official conda have been uploaded to binstar orgs.
   - conda install -n testenv --yes -c soft-matter pims tifffile
   - conda install -n testenv --yes -c nikea mongoengine

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - pandas
     - pyyaml
     - pims
-    - metadatastore >=0.1.0
-    - filestore >=0.1.0
+    - metadatastore >=0.2.0
+    - filestore >=0.2.0
     - channelarchiver
     - six
     - humanize

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   run:
     - python
     - pandas
-    - matplotlib
     - pyyaml
     - pims
     - metadatastore >=0.1.0
@@ -28,7 +27,6 @@ requirements:
     - channelarchiver
     - six
     - humanize
-    - scikit-image
 
 test:
   requires:

--- a/dataportal/__init__.py
+++ b/dataportal/__init__.py
@@ -2,12 +2,13 @@ import sys
 import logging
 from .sources import *
 
-__all__ = ['DataBroker', 'DataMuxer', 'StepScan', 'Images', 'SubtractedImages']
+__all__ = ['DataBroker', 'DataMuxer', 'StepScan', 'get_images', 'get_events',
+           'get_table']
 logger = logging.getLogger(__name__)
 
 
 # generally useful imports
-from .broker import DataBroker, Images, SubtractedImages
+from .broker import DataBroker, get_events, get_table, get_images
 from .muxer import DataMuxer
 from .scans import StepScan
 

--- a/dataportal/broker/__init__.py
+++ b/dataportal/broker/__init__.py
@@ -1,5 +1,5 @@
 from .simple_broker import (DataBroker, Header, get_events, get_table)
 from .handler_registration import register_builtin_handlers
-from .pims_readers import Images, SubtractedImages
+from .pims_readers import get_images
 
 register_builtin_handlers()

--- a/dataportal/broker/pims_readers.py
+++ b/dataportal/broker/pims_readers.py
@@ -2,9 +2,27 @@
 take in headers and detector aliases and return a sliceable generator of arrays."""
 
 from pims import FramesSequence, Frame
-from . import DataBroker
+from . import get_events
 from filestore.api import retrieve
-from skimage import img_as_float
+
+def get_images(headers, name):
+    """
+    Load images from a detector for given Header(s).
+
+    Parameters
+    ----------
+    headers : Header or list of Headers
+    name : string
+        field name (data key) of a detector
+
+    Example
+    -------
+    >>> header = DataBroker[-1]
+    >>> images = Images(header, 'my_detector_lightfield')
+    >>> for image in images:
+            # do something
+    """
+    return Images(headers, name)
 
 
 class Images(FramesSequence):
@@ -16,7 +34,7 @@ class Images(FramesSequence):
         ----------
         headers : Header or list of Headers
         name : str
-            alias (data key) of a detector
+            field name (data key) of a detector
 
         Example
         -------
@@ -25,11 +43,7 @@ class Images(FramesSequence):
         >>> for image in images:
                 # do something
         """
-        all_events = DataBroker.fetch_events(headers, fill=False)
-        # TODO Make this smarter by only grabbing events from the relevant
-        # descriptors. For now, we will do it this way to take advantage of
-        # header validation logical happening in fetch_events.
-        events = [event for event in all_events if name in event.data.keys()]
+        events = get_events(headers, [name], fill=False)
         self._datum_uids = [event.data[name] for event in events]
         self._len = len(self._datum_uids)
         example_frame = retrieve(self._datum_uids[0])
@@ -50,51 +64,3 @@ class Images(FramesSequence):
     def get_frame(self, i):
         img = retrieve(self._datum_uids[i])
         return Frame(img, frame_no=i)
-
-
-class SubtractedImages(FramesSequence):
-    def __init__(self, headers, lightfield_name, darkfield_name):
-        """
-        Load images from a detector for given Header(s). Subtract
-        dark images from each corresponding light image automatically.
-
-        Parameters
-        ----------
-        headers : Header or list of Headers
-        lightfield_name : str
-            alias (data key) of lightfield images
-        darkfield_name : str
-            alias (data key) of darkfield images
-
-        Example
-        -------
-        >>> header = DataBroker[-1]
-        >>> images = SubtractedImages(header, 'my_lightfield', 'my_darkfield')
-        >>> for image in images:
-                # do something
-        """
-        self.light = Images(headers, lightfield_name)
-        self.dark = Images(headers, darkfield_name)
-        if len(self.light) != len(self.dark):
-            raise ValueError("The streams from {0} and {1} have unequal "
-                             "length and cannot be automatically subtracted.")
-        self._len = len(self.light)
-        example = img_as_float(self.light[0]) - img_as_float(self.dark[0])
-        self._dtype = example.dtype
-        self._shape = example.shape
-
-    def get_frame(self, i):
-        # Convert to float to avoid out-of-bounds wrap-around errors,
-        # as in 10-11 = 255.
-        return img_as_float(self.light[i]) - img_as_float(self.dark[i])
-
-    @property
-    def pixel_type(self):
-        return self._dtype
-
-    @property
-    def frame_shape(self):
-        return self._shape
-
-    def __len__(self):
-        return self._len

--- a/dataportal/tests/test_misc.py
+++ b/dataportal/tests/test_misc.py
@@ -1,5 +1,5 @@
 from ..utils.diagnostics import watermark
-from ..broker.pims_readers import Images, SubtractedImages
+from ..broker.pims_readers import Images, get_images
 from ..broker import DataBroker as db
 from ..examples.sample_data import image_and_scalar
 from metadatastore.utils.testing import mds_setup, mds_teardown
@@ -12,7 +12,7 @@ from numpy.testing.utils import assert_array_equal
 def test_watermark():
     watermark()
 
-def test_pims_images():
+def test_pims_images_old_api():
     header = db[-1]
     images = Images(header, 'img')
     images[:5]  # smoke test
@@ -20,18 +20,15 @@ def test_pims_images():
     assert_array_equal(images.frame_shape, images[0].shape)
     assert_equal(len(images), image_and_scalar.num1)
 
-def test_pims_subtracted_images():
-    header = db[-1]
-    images = Images(header, 'img')
-    s_images = SubtractedImages(header, 'img', 'img')
-    s_images[:5]  # smoke test
-    assert_equal(s_images.pixel_type, np.float64)
-    assert_array_equal(s_images.frame_shape, s_images[0].shape)
-    assert_equal(len(s_images), image_and_scalar.num1)
 
-    # We are subtracting an image from itself, so the result should be zero.
-    expected = np.zeros(s_images.frame_shape)
-    assert_array_equal(s_images[0], expected)
+def test_pims_images():
+    header = db[-1]
+    images = get_images(header, 'img')
+    images[:5]  # smoke test
+    assert_equal(images.pixel_type, np.float64)
+    assert_array_equal(images.frame_shape, images[0].shape)
+    assert_equal(len(images), image_and_scalar.num1)
+
 
 def setup():
     mds_setup()

--- a/doc/source/whats_new/v0.2.1.txt
+++ b/doc/source/whats_new/v0.2.1.txt
@@ -1,0 +1,9 @@
+Dataportal v0.2.1
+-----------------
+
+API Changes
+===========
+
+* `get_images` (as alias for `Images`) added for consistency with other
+  function names
+* `SubtractedImages` removed; prefer PIMS pipeline feature.


### PR DESCRIPTION
- `get_images` is a factory for `Images`, for consistency with get_\* funcs
- `SubtractedImages` should be done using `pims.pipeline`, and removing it
  removes dataportal's incongruous dependency on scikit-image
- the `Images` implementation is now faster, using get_events to read in
  only the events with the relevant data key

@sameera2004 Would you test this and then update the example notebook we wrote to use `get_images()` instead of `Images()`?
