### PR TITLE
FIX: Localize times using tzlocal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
   - 'pip install prettytable'
   - 'pip install humanize'
   - 'pip install boltons'
+  - 'pip install tzlocal'
   - 'pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore'
   - 'pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore'
   - 'pip install https://github.com/NSLS-II/channelarchiver/zipball/master#egg=channelarchiver'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - channelarchiver
     - six
     - humanize
+    - tzlocal
 
 test:
   requires:

--- a/dataportal/muxer/data_muxer.py
+++ b/dataportal/muxer/data_muxer.py
@@ -38,6 +38,7 @@ import six
 from collections import namedtuple, deque
 import logging
 import pandas as pd
+import tzlocal
 import numpy as np
 from scipy.interpolate import interp1d
 import pandas.core.groupby  # to get custom exception
@@ -45,6 +46,8 @@ import pandas.core.groupby  # to get custom exception
 
 logger = logging.getLogger(__name__)
 __all__ = ['DataMuxer', 'dataframe_to_dict']
+
+TZ = str(tzlocal.get_localzone())
 
 
 class BinningError(Exception):
@@ -480,9 +483,11 @@ class DataMuxer(object):
 
     def _maybe_convert_times(self, data):
         if self.convert_times:
+            t = pd.to_datetime(data, unit='s', utc=True).dt.tz_localize(TZ)
             if self.reference_time is None:
-                return pd.to_datetime(data, unit='s')
-            return pd.to_datetime(data, unit='s') - self.reference_time
+                return t
+            else:
+                return t - self.reference_time
         return data  # no-op
 
     def include_timestamp_data(self, source_name):


### PR DESCRIPTION
Supercedes aborted attempt in #192. The key, if you are curious, is using the `.dt` accessor attribute; in #192 you were modifying the _index_ not the column.

Adds dependencies on tzlocal, a light package that is not in official conda but is already in our conda-prescriptions and on the `latest` channel for some reason I don't recall. According to SO, there is no cross-platform way to obtain the local tz using Python stdlib.
